### PR TITLE
MC-35984: Returns edit page becomes broken after Shipping Label for RMA was created

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -1,1 +1,11 @@
-{}
+{
+  "MC-35984": {
+    "magento/magento2-ee-base": {
+      "Fixes issue in RMA edit page with shipping label": {
+        "2.4.0": {
+          "file": "commerce/MC-35984__fixes_issue_in_rma_edit_page_with_shipping_label__2.4.0.patch"
+        }
+      }
+    }
+  }
+}

--- a/patches/commerce/MC-35984__fixes_issue_in_rma_edit_page_with_shipping_label__2.4.0.patch
+++ b/patches/commerce/MC-35984__fixes_issue_in_rma_edit_page_with_shipping_label__2.4.0.patch
@@ -1,0 +1,36 @@
+diff -Nuar a/vendor/magento/module-rma/Block/Adminhtml/Rma/Edit/Tab/General/Shippingmethod.php b/vendor/magento/module-rma/Block/Adminhtml/Rma/Edit/Tab/General/Shippingmethod.php
+--- a/vendor/magento/module-rma/Block/Adminhtml/Rma/Edit/Tab/General/Shippingmethod.php
++++ b/vendor/magento/module-rma/Block/Adminhtml/Rma/Edit/Tab/General/Shippingmethod.php
+@@ -8,6 +8,7 @@
+ use Magento\Framework\Pricing\PriceCurrencyInterface;
+ use Magento\Framework\App\ObjectManager;
+ use Magento\Framework\Serialize\Serializer\Json;
++use Magento\Shipping\Helper\Carrier;
+
+ /**
+  * Shipping Method Block at RMA page
+@@ -84,6 +85,7 @@ class Shippingmethod extends \Magento\Rma\Block\Adminhtml\Rma\Edit\Tab\General\A
+      * @param PriceCurrencyInterface $priceCurrency
+      * @param array $data
+      * @param Json|null $json
++     * @param Carrier|null $carrierHelper
+      */
+     public function __construct(
+         \Magento\Backend\Block\Template\Context $context,
+@@ -93,13 +95,15 @@ public function __construct(
+         \Magento\Rma\Model\ShippingFactory $shippingFactory,
+         PriceCurrencyInterface $priceCurrency,
+         array $data = [],
+-        Json $json = null
++        Json $json = null,
++        Carrier $carrierHelper = null
+     ) {
+         $this->priceCurrency = $priceCurrency;
+         $this->_taxData = $taxData;
+         $this->_rmaData = $rmaData;
+         $this->_shippingFactory = $shippingFactory;
+         $this->json = $json ?: ObjectManager::getInstance()->get(Json::class);
++        $data['carrierHelper'] = $carrierHelper ?? ObjectManager::getInstance()->get(Carrier::class);
+         parent::__construct($context, $registry, $data);
+     }
+


### PR DESCRIPTION
### Description
Fixes issue about broken "Returns" edit page after Shipping Label for RMA was created.

### Fixed Issues (if relevant)
1. https://jira.corp.magento.com/browse/MC-35984