### PR TITLE
Test: PayPal PayFlow checkout breaks in Chrome due to introduction of default functionality for cookies that don't explicitly set SameSite property

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -1,1 +1,18 @@
-{}
+{
+  "MDVA-25602": {
+    "magento/magento2-base": {
+      "Fixes issue with PayPal Payflow Pro payment method and treating cookies as SameSite=Lax by default in the Chrome 80 browser and API response redirect to customer login page": {
+        ">=2.3.3 <2.3.5": {
+          "file": "os/MDVA-25602__PayflowPro_checkout_broken_with_SameSite_Cookie__2.3.0.patch"
+        }
+      }
+    },
+    "magento/magento2-ee-base": {
+      "Fixes issue with PayPal Payflow Pro payment method and treating cookies as SameSite=Lax by default in the Chrome 80 browser and API response redirect to customer login page": {
+        ">=2.3.0 <2.3.5": {
+          "file": "commerce/MDVA-25602__PayflowPro_API_response_302_redirect_to_login_page__2.3.4.patch"
+        }
+      }
+    }
+  }
+}

--- a/patches/commerce/MDVA-25602__payflowpro_api_response_302_redirect_to_login_page__2.3.4.patch
+++ b/patches/commerce/MDVA-25602__payflowpro_api_response_302_redirect_to_login_page__2.3.4.patch
@@ -1,0 +1,14 @@
+diff --git a/vendor/magento/module-website-restriction/etc/webrestrictions.xml b/vendor/magento/module-website-restriction/etc/webrestrictions.xml
+index 025df9529b1..c8c4e2f7536 100644
+--- a/vendor/magento/module-website-restriction/etc/webrestrictions.xml
++++ b/vendor/magento/module-website-restriction/etc/webrestrictions.xml
+@@ -24,7 +24,8 @@
+     <action path="paypal_payflow_silentPost" type="generic" />
+     <action path="paypal_payflowadvanced_silentPost" type="generic" />
+     <action path="authorizenet_directpost_payment_response" type="generic" />
+-    <action path="transparent_payment_response" type="generic" />
++    <action path="paypal_transparent_response" type="generic" />
++    <action path="paypal_transparent_redirect" type="generic" />
+     <action path="customer_account_create" type="register" />
+     <action path="customer_account_createPost" type="register" />
+ </config>

--- a/patches/os/mdva-25602__payflowpro_checkout_broken_with_samesite_cookie__2.3.0.patch
+++ b/patches/os/mdva-25602__payflowpro_checkout_broken_with_samesite_cookie__2.3.0.patch
@@ -1,0 +1,409 @@
+diff --git a/vendor/magento/module-payment/Block/Transparent/Redirect.php b/vendor/magento/module-payment/Block/Transparent/Redirect.php
+new file mode 100644
+index 00000000000..aeaeee7e4d2
+--- /dev/null
++++ b/vendor/magento/module-payment/Block/Transparent/Redirect.php
+@@ -0,0 +1,60 @@
++<?php
++/**
++ * Copyright © Magento, Inc. All rights reserved.
++ * See COPYING.txt for license details.
++ */
++namespace Magento\Payment\Block\Transparent;
++
++use Magento\Framework\UrlInterface;
++use Magento\Framework\View\Element\Template;
++use Magento\Framework\View\Element\Template\Context;
++
++/**
++ * Redirect block for register specific params in layout
++ */
++class Redirect extends Template
++{
++    /**
++     * Route path key to make redirect url.
++     */
++    private const ROUTE_PATH = 'route_path';
++
++    /**
++     * @var UrlInterface
++     */
++    private $url;
++
++    /**
++     * @param Context $context
++     * @param UrlInterface $url
++     * @param array $data
++     */
++    public function __construct(
++        Context $context,
++        UrlInterface $url,
++        array $data = []
++    ) {
++        $this->url = $url;
++        parent::__construct($context, $data);
++    }
++
++    /**
++     * Returns url for redirect.
++     *
++     * @return string
++     */
++    public function getRedirectUrl(): string
++    {
++        return $this->url->getUrl($this->getData(self::ROUTE_PATH));
++    }
++
++    /**
++     * Returns params to be redirected.
++     *
++     * @return array
++     */
++    public function getPostParams(): array
++    {
++        return (array)$this->_request->getPostValue();
++    }
++}
+diff --git a/vendor/magento/module-payment/view/adminhtml/templates/transparent/redirect.phtml b/vendor/magento/module-payment/view/adminhtml/templates/transparent/redirect.phtml
+new file mode 100644
+index 00000000000..17fbdf780a4
+--- /dev/null
++++ b/vendor/magento/module-payment/view/adminhtml/templates/transparent/redirect.phtml
+@@ -0,0 +1,21 @@
++<?php
++/**
++ * Copyright © Magento, Inc. All rights reserved.
++ * See COPYING.txt for license details.
++ */
++
++/** @var \Magento\Payment\Block\Transparent\Redirect $block */
++$params = $block->getPostParams();
++$redirectUrl = $block->getRedirectUrl();
++?>
++<html>
++<head></head>
++<body onload="document.forms['proxy_form'].submit()">
++<form id="proxy_form" action="<?= $block->escapeUrl($redirectUrl) ?>"
++      method="POST" hidden enctype="application/x-www-form-urlencoded" class="no-display">
++    <?php foreach ($params as $name => $value):?>
++        <input value="<?= $block->escapeHtmlAttr($value) ?>" name="<?= $block->escapeHtmlAttr($name) ?>" type="hidden"/>
++    <?php endforeach?>
++</form>
++</body>
++</html>
+diff --git a/vendor/magento/module-payment/view/frontend/templates/transparent/redirect.phtml b/vendor/magento/module-payment/view/frontend/templates/transparent/redirect.phtml
+new file mode 100644
+index 00000000000..17fbdf780a4
+--- /dev/null
++++ b/vendor/magento/module-payment/view/frontend/templates/transparent/redirect.phtml
+@@ -0,0 +1,21 @@
++<?php
++/**
++ * Copyright © Magento, Inc. All rights reserved.
++ * See COPYING.txt for license details.
++ */
++
++/** @var \Magento\Payment\Block\Transparent\Redirect $block */
++$params = $block->getPostParams();
++$redirectUrl = $block->getRedirectUrl();
++?>
++<html>
++<head></head>
++<body onload="document.forms['proxy_form'].submit()">
++<form id="proxy_form" action="<?= $block->escapeUrl($redirectUrl) ?>"
++      method="POST" hidden enctype="application/x-www-form-urlencoded" class="no-display">
++    <?php foreach ($params as $name => $value):?>
++        <input value="<?= $block->escapeHtmlAttr($value) ?>" name="<?= $block->escapeHtmlAttr($name) ?>" type="hidden"/>
++    <?php endforeach?>
++</form>
++</body>
++</html>
+diff --git a/vendor/magento/module-paypal/Controller/Adminhtml/Transparent/Redirect.php b/vendor/magento/module-paypal/Controller/Adminhtml/Transparent/Redirect.php
+new file mode 100644
+index 00000000000..8201761cc3a
+--- /dev/null
++++ b/vendor/magento/module-paypal/Controller/Adminhtml/Transparent/Redirect.php
+@@ -0,0 +1,13 @@
++<?php
++/**
++ * Copyright © Magento, Inc. All rights reserved.
++ * See COPYING.txt for license details.
++ */
++namespace Magento\Paypal\Controller\Adminhtml\Transparent;
++
++/**
++ * Class for redirecting the Paypal response result to Magento controller.
++ */
++class Redirect extends \Magento\Paypal\Controller\Transparent\Redirect
++{
++}
+diff --git a/vendor/magento/module-paypal/Controller/Transparent/Redirect.php b/vendor/magento/module-paypal/Controller/Transparent/Redirect.php
+new file mode 100644
+index 00000000000..c6cee15d23c
+--- /dev/null
++++ b/vendor/magento/module-paypal/Controller/Transparent/Redirect.php
+@@ -0,0 +1,98 @@
++<?php
++/**
++ * Copyright © Magento, Inc. All rights reserved.
++ * See COPYING.txt for license details.
++ */
++namespace Magento\Paypal\Controller\Transparent;
++
++use Magento\Framework\App\Action\Context;
++use Magento\Framework\App\Action\HttpPostActionInterface;
++use Magento\Framework\App\CsrfAwareActionInterface;
++use Magento\Framework\App\Request\InvalidRequestException;
++use Magento\Framework\App\RequestInterface;
++use Magento\Framework\Controller\ResultInterface;
++use Magento\Framework\Exception\LocalizedException;
++use Magento\Framework\View\Result\LayoutFactory;
++use Magento\Payment\Model\Method\Logger;
++use Magento\Paypal\Model\Payflow\Transparent;
++
++/**
++ * Class for redirecting the Paypal response result to Magento controller.
++ */
++class Redirect extends \Magento\Framework\App\Action\Action implements CsrfAwareActionInterface, HttpPostActionInterface
++{
++    /**
++     * @var LayoutFactory
++     */
++    private $resultLayoutFactory;
++
++    /**
++     * @var Transparent
++     */
++    private $transparent;
++
++    /**
++     * @var Logger
++     */
++    private $logger;
++
++    /**
++     * Constructor
++     *
++     * @param Context $context
++     * @param LayoutFactory $resultLayoutFactory
++     * @param Transparent $transparent
++     * @param Logger $logger
++     */
++    public function __construct(
++        Context $context,
++        LayoutFactory $resultLayoutFactory,
++        Transparent $transparent,
++        Logger $logger
++    ) {
++        $this->resultLayoutFactory = $resultLayoutFactory;
++        $this->transparent = $transparent;
++        $this->logger = $logger;
++
++        parent::__construct($context);
++    }
++
++    /**
++     * @inheritDoc
++     */
++    public function createCsrfValidationException(
++        RequestInterface $request
++    ): ?InvalidRequestException {
++        return null;
++    }
++
++    /**
++     * @inheritDoc
++     */
++    public function validateForCsrf(RequestInterface $request): ?bool
++    {
++        return true;
++    }
++
++    /**
++     * Saves the payment in quote
++     *
++     * @return ResultInterface
++     * @throws LocalizedException
++     */
++    public function execute()
++    {
++        $gatewayResponse = (array)$this->getRequest()->getPostValue();
++        $this->logger->debug(
++            ['PayPal PayflowPro redirect:' => $gatewayResponse],
++            $this->transparent->getDebugReplacePrivateDataKeys(),
++            $this->transparent->getDebugFlag()
++        );
++
++        $resultLayout = $this->resultLayoutFactory->create();
++        $resultLayout->addDefaultHandle();
++        $resultLayout->getLayout()->getUpdate()->load(['transparent_payment_redirect']);
++
++        return $resultLayout;
++    }
++}
+diff --git a/vendor/magento/module-paypal/Model/Payflow/Service/Request/SecureToken.php b/vendor/magento/module-paypal/Model/Payflow/Service/Request/SecureToken.php
+index da5599984b7..3ae93367328 100644
+--- a/vendor/magento/module-paypal/Model/Payflow/Service/Request/SecureToken.php
++++ b/vendor/magento/module-paypal/Model/Payflow/Service/Request/SecureToken.php
+@@ -66,9 +66,9 @@ class SecureToken
+         $request->setAmt(0);
+         $request->setCreatesecuretoken('Y');
+         $request->setSecuretokenid($this->mathRandom->getUniqueHash());
+-        $request->setReturnurl($this->url->getUrl('paypal/transparent/response'));
+-        $request->setErrorurl($this->url->getUrl('paypal/transparent/response'));
+-        $request->setCancelurl($this->url->getUrl('paypal/transparent/cancel'));
++        $request->setReturnurl($this->url->getUrl('paypal/transparent/redirect'));
++        $request->setErrorurl($this->url->getUrl('paypal/transparent/redirect'));
++        $request->setCancelurl($this->url->getUrl('paypal/transparent/redirect'));
+         $request->setDisablereceipt('TRUE');
+         $request->setSilenttran('TRUE');
+
+diff --git a/vendor/magento/module-paypal/Model/Payflow/Service/Response/Transaction.php b/vendor/magento/module-paypal/Model/Payflow/Service/Response/Transaction.php
+index 06a8a5b680b..09a73580feb 100644
+--- a/vendor/magento/module-paypal/Model/Payflow/Service/Response/Transaction.php
++++ b/vendor/magento/module-paypal/Model/Payflow/Service/Response/Transaction.php
+@@ -17,7 +17,8 @@ use Magento\Quote\Model\Quote\Payment;
+ use Magento\Sales\Api\Data\OrderPaymentInterface;
+
+ /**
+- * Class Transaction
++ * Process PayPal transaction response.
++ *
+  */
+ class Transaction
+ {
+@@ -87,7 +88,7 @@ class Transaction
+         $response = $this->transparent->mapGatewayResponse((array) $gatewayTransactionResponse, $response);
+
+         $this->logger->debug(
+-            (array) $gatewayTransactionResponse,
++            ['PayPal PayflowPro response:' => (array)$gatewayTransactionResponse],
+             (array) $this->transparent->getDebugReplacePrivateDataKeys(),
+             (bool) $this->transparent->getDebugFlag()
+         );
+diff --git a/vendor/magento/module-paypal/Plugin/TransparentSessionChecker.php b/vendor/magento/module-paypal/Plugin/TransparentSessionChecker.php
+new file mode 100644
+index 00000000000..5157ba3208f
+--- /dev/null
++++ b/vendor/magento/module-paypal/Plugin/TransparentSessionChecker.php
+@@ -0,0 +1,50 @@
++<?php
++/**
++ * Copyright © Magento, Inc. All rights reserved.
++ * See COPYING.txt for license details.
++ */
++declare(strict_types=1);
++
++namespace Magento\Paypal\Plugin;
++
++use Magento\Framework\App\Request\Http;
++use Magento\Framework\Session\SessionStartChecker;
++
++/**
++ * Intended to preserve session cookie after submitting POST form from PayPal to Magento controller.
++ */
++class TransparentSessionChecker
++{
++    private const TRANSPARENT_REDIRECT_PATH = 'paypal/transparent/redirect';
++
++    /**
++     * @var Http
++     */
++    private $request;
++
++    /**
++     * @param Http $request
++     */
++    public function __construct(
++        Http $request
++    ) {
++        $this->request = $request;
++    }
++
++    /**
++     * Prevents session starting while instantiating PayPal transparent redirect controller.
++     *
++     * @param SessionStartChecker $subject
++     * @param bool $result
++     * @return bool
++     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
++     */
++    public function afterCheck(SessionStartChecker $subject, bool $result): bool
++    {
++        if ($result === false) {
++            return false;
++        }
++
++        return strpos((string)$this->request->getPathInfo(), self::TRANSPARENT_REDIRECT_PATH) === false;
++    }
++}
+diff --git a/vendor/magento/module-paypal/etc/di.xml b/vendor/magento/module-paypal/etc/di.xml
+index c0141bbb321..dc03a9727e3 100644
+--- a/vendor/magento/module-paypal/etc/di.xml
++++ b/vendor/magento/module-paypal/etc/di.xml
+@@ -190,6 +190,9 @@
+             <argument name="paymentTokenFactory" xsi:type="object">Magento\Vault\Model\CreditCardTokenFactory</argument>
+         </arguments>
+     </type>
++    <type name="Magento\Framework\Session\SessionStartChecker">
++        <plugin name="transparent_session_checker" type="Magento\Paypal\Plugin\TransparentSessionChecker"/>
++    </type>
+     <type name="Magento\Config\Model\Config\TypePool">
+         <arguments>
+             <argument name="sensitive" xsi:type="array">
+diff --git a/vendor/magento/module-paypal/etc/frontend/page_types.xml b/vendor/magento/module-paypal/etc/frontend/page_types.xml
+index 133ab1ca761..1da5d54fb38 100644
+--- a/vendor/magento/module-paypal/etc/frontend/page_types.xml
++++ b/vendor/magento/module-paypal/etc/frontend/page_types.xml
+@@ -14,6 +14,7 @@
+     <type id="paypal_payflow_form" label="Paypal Payflow Form"/>
+     <type id="transparent" label="Paypal Payflow TR Form"/>
+     <type id="transparent_payment_response" label="Paypal Payflow TR Response"/>
++    <type id="transparent_payment_redirect" label="Paypal Payflow TR Redirect"/>
+     <type id="paypal_payflow_returnurl" label="Paypal Payflow Return URL"/>
+     <type id="paypal_payflowadvanced_cancelpayment" label="Paypal Payflow Advanced Cancel Payment"/>
+     <type id="paypal_payflowadvanced_form" label="Paypal Payflow Advanced Form"/>
+diff --git a/vendor/magento/module-paypal/view/adminhtml/layout/transparent_payment_redirect.xml b/vendor/magento/module-paypal/view/adminhtml/layout/transparent_payment_redirect.xml
+new file mode 100644
+index 00000000000..01acf03c0d0
+--- /dev/null
++++ b/vendor/magento/module-paypal/view/adminhtml/layout/transparent_payment_redirect.xml
+@@ -0,0 +1,16 @@
++<?xml version="1.0"?>
++<!--
++/**
++ * Copyright © Magento, Inc. All rights reserved.
++ * See COPYING.txt for license details.
++ */
++-->
++<layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
++    <container name="root" label="Root">
++        <block class="Magento\Payment\Block\Transparent\Redirect" name="transparent_redirect" template="Magento_Payment::transparent/redirect.phtml">
++            <arguments>
++                <argument name="route_path" xsi:type="string">paypal/transparent/response</argument>
++            </arguments>
++        </block>
++    </container>
++</layout>
+diff --git a/vendor/magento/module-paypal/view/frontend/layout/transparent_payment_redirect.xml b/vendor/magento/module-paypal/view/frontend/layout/transparent_payment_redirect.xml
+new file mode 100644
+index 00000000000..01acf03c0d0
+--- /dev/null
++++ b/vendor/magento/module-paypal/view/frontend/layout/transparent_payment_redirect.xml
+@@ -0,0 +1,16 @@
++<?xml version="1.0"?>
++<!--
++/**
++ * Copyright © Magento, Inc. All rights reserved.
++ * See COPYING.txt for license details.
++ */
++-->
++<layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
++    <container name="root" label="Root">
++        <block class="Magento\Payment\Block\Transparent\Redirect" name="transparent_redirect" template="Magento_Payment::transparent/redirect.phtml">
++            <arguments>
++                <argument name="route_path" xsi:type="string">paypal/transparent/response</argument>
++            </arguments>
++        </block>
++    </container>
++</layout>


### PR DESCRIPTION
Fixes issue with PayPal Payflow Pro payment method and treating cookies as SameSite=Lax by default in the Chrome 80 browser and API response redirect to customer login page

### Description
MDVA-25602__PayflowPro_checkout_broken_with_SameSite_Cookie__2.3.*.patch provides fix for Broken Checkout with SameSite Cookie Changes from Chrome 80 via PayPal Payflow Pro payment method

### Fixed Issues 
1. https://jira.corp.magento.com/browse/MDVA-25602
