### PR TITLE
1.0.2 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/quality-patches",
     "description": "Provides quality patches for Magento 2",
     "type": "magento2-component",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "license": "proprietary",
     "repositories": {
         "repo": {

--- a/patches.json
+++ b/patches.json
@@ -33,7 +33,7 @@
   "MDVA-26694": {
     "magento/magento2-base": {
       "Product and catalog caches will expire as scheduled. Previously, caches expire daily, as сron runs the 'catalogrule_apply_all' task once a day which re-indexes all the catalog rules and its dependent indexers and clears the cache for all products and categories.": {
-        ">=2.3.0 <2.4.0": {
+        ">=2.3.0 <=2.3.5-p2 || 2.4.0": {
           "file": "os/MDVA-26694__fix_product_and_catalog_cache_expiration_daily__2.3.1.patch"
         }
       }
@@ -42,7 +42,7 @@
   "MDVA-30131": {
     "magento/magento2-base": {
       "Code was not storing false values for custom attributes in Elastic Search, so filter was possible using 'No' for boolean attributes using layered navigation. To address that, some boolean checks have been replaces for null checks, and an array_filter call has been erased completely as no callback function was provided in it, thus always returning false as 'all entries of array equal to FALSE (see converting to boolean) will be removed'.": {
-        ">=2.3.4 <=2.3.5-p2": {
+        ">=2.3.4 <=2.3.5-p2 || 2.4.0": {
           "file": "os/MDVA-30131__fix_storing_boolean_values_for_custom_attributes_in_Elastic_Search__2.3.4.patch"
         }
       }
@@ -51,7 +51,7 @@
   "MDVA-27825": {
     "magento/magento2-base": {
       "Big data customer export issue. Memory leak prevented by adding clearing of Customer objects in \\Magento\\Framework\\Model\\ResourceModel\\Db\\VersionControl\\Snapshot class": {
-        ">=2.3.0 <2.4.0": {
+        ">=2.3.0 <=2.3.5-p2 || 2.4.0": {
           "file": "os/MDVA-27825__fix_memory_leak_prevent_customer_export__2.3.3.patch"
         }
       }
@@ -69,7 +69,7 @@
   "MDVA-29835": {
     "magento/magento2-ee-base": {
       "Issue fixed: Two gift card codes can be seen for the order.\nRoot Cause: cron jobs called \\Magento\\GiftCard\\Observer\\GenerateGiftCardAccountsInvoice::execute() and this method did not check if giftcard codes already were generated during invoice creation.": {
-        ">2.3.1 <=2.4.0": {
+        ">2.3.1 <=2.3.5-p2 || 2.4.0": {
           "file": "commerce/MDVA-29835__two_gift_card_codes_can_be_seen_for_the_order__2.3.4-p2.patch"
         }
       }
@@ -78,7 +78,7 @@
   "MDVA-29344": {
     "magento/module-page-builder": {
       "Page builder hangs after copying text from a header element to a text element.": {
-        ">=2.3.5 <=2.4.0": {
+        ">=2.3.5 <=2.3.5-p2 || 2.4.0": {
           "file": "commerce/MDVA-29344__fix_page_builder_hangs_after_text_copying__2.3.5-p1.patch"
         }
       }

--- a/patches.json
+++ b/patches.json
@@ -39,11 +39,11 @@
       }
     }
   },
-  "MDVA-29883": {
+  "MDVA-30131": {
     "magento/magento2-base": {
       "Code was not storing false values for custom attributes in Elastic Search, so filter was possible using 'No' for boolean attributes using layered navigation. To address that, some boolean checks have been replaces for null checks, and an array_filter call has been erased completely as no callback function was provided in it, thus always returning false as 'all entries of array equal to FALSE (see converting to boolean) will be removed'.": {
         ">=2.3.4 <=2.3.5-p2": {
-          "file": "os/MDVA-29883__fix_storing_boolean_values_for_custom_attributes_in_Elastic_Search__2.3.4.patch"
+          "file": "os/MDVA-30131__fix_storing_boolean_values_for_custom_attributes_in_Elastic_Search__2.3.4.patch"
         }
       }
     }
@@ -69,7 +69,7 @@
   "MDVA-29835": {
     "magento/magento2-ee-base": {
       "Issue fixed: Two gift card codes can be seen for the order.\nRoot Cause: cron jobs called \\Magento\\GiftCard\\Observer\\GenerateGiftCardAccountsInvoice::execute() and this method did not check if giftcard codes already were generated during invoice creation.": {
-        ">=2.3.0 <=2.4.0": {
+        ">2.3.1 <=2.4.0": {
           "file": "commerce/MDVA-29835__two_gift_card_codes_can_be_seen_for_the_order__2.3.4-p2.patch"
         }
       }

--- a/patches.json
+++ b/patches.json
@@ -21,6 +21,69 @@
       }
     }
   },
+  "MDVA-30052": {
+    "magento/magento2-base": {
+      "Customer data section invalidation logic has been improved. This release introduces a new way of invalidating all customer sections data that avoids a known issue with local storage when custom `sections.xml` invalidations are active. (Previously, private content (local storage) was not correctly populated when you had a custom *etc/frontend/sections.xml* with action invalidations).": {
+        ">=2.3.2-p2 <2.3.5": {
+          "file": "os/MDVA-30052__customer_data_section_invalidation_logic_improvement__2.3.4-p2.patch"
+        }
+      }
+    }
+  },
+  "MDVA-26694": {
+    "magento/magento2-base": {
+      "Product and catalog caches will expire as scheduled. Previously, caches expire daily, as сron runs the 'catalogrule_apply_all' task once a day which re-indexes all the catalog rules and its dependent indexers and clears the cache for all products and categories.": {
+        ">=2.3.0 <2.4.0": {
+          "file": "os/MDVA-26694__fix_product_and_catalog_cache_expiration_daily__2.3.1.patch"
+        }
+      }
+    }
+  },
+  "MDVA-29883": {
+    "magento/magento2-base": {
+      "Code was not storing false values for custom attributes in Elastic Search, so filter was possible using 'No' for boolean attributes using layered navigation. To address that, some boolean checks have been replaces for null checks, and an array_filter call has been erased completely as no callback function was provided in it, thus always returning false as 'all entries of array equal to FALSE (see converting to boolean) will be removed'.": {
+        ">=2.3.4 <=2.3.5-p2": {
+          "file": "os/MDVA-29883__fix_storing_boolean_values_for_custom_attributes_in_Elastic_Search__2.3.4.patch"
+        }
+      }
+    }
+  },
+  "MDVA-27825": {
+    "magento/magento2-base": {
+      "Big data customer export issue. Memory leak prevented by adding clearing of Customer objects in \\Magento\\Framework\\Model\\ResourceModel\\Db\\VersionControl\\Snapshot class": {
+        ">=2.3.0 <2.4.0": {
+          "file": "os/MDVA-27825__fix_memory_leak_prevent_customer_export__2.3.3.patch"
+        }
+      }
+    }
+  },
+  "MDVA-29085": {
+    "magento/magento2-b2b-base": {
+      "After the company has been created through the API, the intended plugin will check if the company is created and dispatch the two emails accordingly.": {
+        ">=2.3.0 <=2.3.5-p1": {
+          "file": "commerce/MDVA-29085__fix_email_confirmation_after_company_created_via_API__2.3.5-p1.patch"
+        }
+      }
+    }
+  },
+  "MDVA-29835": {
+    "magento/magento2-ee-base": {
+      "Issue fixed: Two gift card codes can be seen for the order.\nRoot Cause: cron jobs called \\Magento\\GiftCard\\Observer\\GenerateGiftCardAccountsInvoice::execute() and this method did not check if giftcard codes already were generated during invoice creation.": {
+        ">=2.3.0 <=2.4.0": {
+          "file": "commerce/MDVA-29835__two_gift_card_codes_can_be_seen_for_the_order__2.3.4-p2.patch"
+        }
+      }
+    }
+  },
+  "MDVA-29344": {
+    "magento/module-page-builder": {
+      "Page builder hangs after copying text from a header element to a text element.": {
+        ">=2.3.5 <=2.4.0": {
+          "file": "commerce/MDVA-29344__fix_page_builder_hangs_after_text_copying__2.3.5-p1.patch"
+        }
+      }
+    }
+  },
   "MC-35514": {
     "magento/magento2-base": {
       "Fixes issue with creating a shipping label and adding ordered products to a package in the Create Packages modal window.": {

--- a/patches/commerce/MDVA-29085__fix_email_confirmation_after_company_created_via_API__2.3.5-p1.patch
+++ b/patches/commerce/MDVA-29085__fix_email_confirmation_after_company_created_via_API__2.3.5-p1.patch
@@ -1,0 +1,126 @@
+diff --git a/vendor/magento/module-company/Plugin/Company/Model/EmailNotification.php b/vendor/magento/module-company/Plugin/Company/Model/EmailNotification.php
+new file mode 100644
+index 000000000..55dc2458d
+--- /dev/null
++++ b/vendor/magento/module-company/Plugin/Company/Model/EmailNotification.php
+@@ -0,0 +1,90 @@
++<?php
++/**
++ * Copyright © Magento, Inc. All rights reserved.
++ * See COPYING.txt for license details.
++ */
++declare(strict_types=1);
++
++namespace Magento\Company\Plugin\Company\Model;
++
++use Magento\Backend\Model\UrlInterface;
++use Magento\Company\Api\Data\CompanyInterface;
++use Magento\Company\Model\Company\Save;
++use Magento\Company\Model\Email\Sender;
++use Magento\Customer\Api\CustomerRepositoryInterface;
++use Magento\Framework\Exception\LocalizedException;
++use Magento\Framework\Exception\NoSuchEntityException;
++
++/**
++ * Class EmailNotification
++ *
++ * Email notification plugin notify customer withe emails
++ * after create company account through API
++ */
++class EmailNotification
++{
++    /**
++     * @var Sender
++     */
++    private $companyEmailSender;
++
++    /**
++     * @var UrlInterface
++     */
++    private $urlBuilder;
++
++    /**
++     * @var CustomerRepositoryInterface
++     */
++    private $customerRepository;
++
++    /**
++     * EmailNotification constructor
++     *
++     * @param Sender $companyEmailSender
++     * @param UrlInterface $urlBuilder
++     * @param CustomerRepositoryInterface $customerRepository
++     */
++    public function __construct(
++        Sender $companyEmailSender,
++        UrlInterface $urlBuilder,
++        CustomerRepositoryInterface $customerRepository
++    ) {
++        $this->companyEmailSender = $companyEmailSender;
++        $this->urlBuilder = $urlBuilder;
++        $this->customerRepository = $customerRepository;
++    }
++
++    /**
++     * Notifying customer after creating company account through API
++     *
++     * @param Save $subject
++     * @param CompanyInterface $company
++     * @return CompanyInterface
++     * @throws LocalizedException
++     * @throws NoSuchEntityException
++     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
++     */
++    public function afterSave(
++        Save $subject,
++        CompanyInterface $company
++    ): CompanyInterface {
++        if ($company) {
++            $customerData = $this->customerRepository
++                ->getById(
++                    $company->getSuperUserId()
++                );
++            $companyUrl = $this->urlBuilder
++                ->getUrl(
++                    'company/index/edit',
++                    ['id' => $company->getEntityId()]
++                );
++            $this->companyEmailSender->sendAdminNotificationEmail(
++                $customerData,
++                $company->getCompanyName(),
++                $companyUrl
++            );
++        }
++        return $company;
++    }
++}
+diff --git a/vendor/magento/module-company/etc/webapi_rest/di.xml b/vendor/magento/module-company/etc/webapi_rest/di.xml
+index 0d79ebcde..4880eed90 100644
+--- a/vendor/magento/module-company/etc/webapi_rest/di.xml
++++ b/vendor/magento/module-company/etc/webapi_rest/di.xml
+@@ -12,4 +12,7 @@
+     <type name="Magento\Quote\Api\CartManagementInterface">
+         <plugin name="company_blocked_validate" type="Magento\Company\Plugin\Quote\Api\CartManagementInterfacePlugin" />
+     </type>
++    <type name="Magento\Company\Model\Company\Save">
++        <plugin name="notify_email_after_save" type="Magento\Company\Plugin\Company\Model\EmailNotification" />
++    </type>
+ </config>
+diff --git a/vendor/magento/module-company/etc/webapi_soap/di.xml b/vendor/magento/module-company/etc/webapi_soap/di.xml
+new file mode 100644
+index 000000000..8d84cb1c2
+--- /dev/null
++++ b/vendor/magento/module-company/etc/webapi_soap/di.xml
+@@ -0,0 +1,12 @@
++<?xml version="1.0"?>
++<!--
++/**
++ * Copyright © Magento, Inc. All rights reserved.
++ * See COPYING.txt for license details.
++ */
++-->
++<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
++    <type name="Magento\Company\Model\Company\Save">
++        <plugin name="notify_email_after_save" type="Magento\Company\Plugin\Company\Model\EmailNotification" />
++    </type>
++</config>

--- a/patches/commerce/MDVA-29344__fix_page_builder_hangs_after_text_copying__2.3.5-p1.patch
+++ b/patches/commerce/MDVA-29344__fix_page_builder_hangs_after_text_copying__2.3.5-p1.patch
@@ -1,0 +1,26 @@
+diff --git a/vendor/magento/module-page-builder/view/adminhtml/web/js/content-type/text/preview.js b/vendor/magento/module-page-builder/view/adminhtml/web/js/content-type/text/preview.js
+index 35264feb4..8f8cd6542 100644
+--- a/vendor/magento/module-page-builder/view/adminhtml/web/js/content-type/text/preview.js
++++ b/vendor/magento/module-page-builder/view/adminhtml/web/js/content-type/text/preview.js
+@@ -136,6 +136,8 @@ define(["jquery", "Magento_PageBuilder/js/events", "underscore", "Magento_PageBu
+ 
+       var wysiwygConfig = this.config.additional_data.wysiwygConfig.wysiwygConfigData;
+ 
++      wysiwygConfig.adapter.settings.paste_as_text = true;
++
+       if (focus) {
+         wysiwygConfig.adapter.settings.auto_focus = this.element.id;
+ 
+diff --git a/vendor/magento/module-page-builder/view/adminhtml/web/ts/js/content-type/text/preview.ts b/vendor/magento/module-page-builder/view/adminhtml/web/ts/js/content-type/text/preview.ts
+index 6c33f1e3e..245020af0 100644
+--- a/vendor/magento/module-page-builder/view/adminhtml/web/ts/js/content-type/text/preview.ts
++++ b/vendor/magento/module-page-builder/view/adminhtml/web/ts/js/content-type/text/preview.ts
+@@ -149,6 +149,8 @@ export default class Preview extends BasePreview {
+ 
+         const wysiwygConfig = this.config.additional_data.wysiwygConfig.wysiwygConfigData;
+ 
++        wysiwygConfig.adapter.settings.paste_as_text = true;
++
+         if (focus) {
+             wysiwygConfig.adapter.settings.auto_focus = this.element.id;
+             wysiwygConfig.adapter.settings.init_instance_callback = () => {

--- a/patches/commerce/MDVA-29835__two_gift_card_codes_can_be_seen_for_the_order__2.3.4-p2.patch
+++ b/patches/commerce/MDVA-29835__two_gift_card_codes_can_be_seen_for_the_order__2.3.4-p2.patch
@@ -1,0 +1,74 @@
+diff --git a/vendor/magento/module-gift-card/Observer/GenerateGiftCardAccountsInvoice.php b/vendor/magento/module-gift-card/Observer/GenerateGiftCardAccountsInvoice.php
+index 76d02836a5b..3322e3e6065 100644
+--- a/vendor/magento/module-gift-card/Observer/GenerateGiftCardAccountsInvoice.php
++++ b/vendor/magento/module-gift-card/Observer/GenerateGiftCardAccountsInvoice.php
+@@ -19,6 +19,7 @@ use Magento\Sales\Api\Data\OrderItemInterface;
+ use Magento\Sales\Model\Order\Invoice;
+ use Magento\Sales\Model\Order\Item;
+ use Magento\Store\Model\ScopeInterface;
++use Magento\Sales\Model\Order;
+ 
+ /**
+  * Gift cards generator observer called on invoice after save
+@@ -66,7 +67,7 @@ class GenerateGiftCardAccountsInvoice implements ObserverInterface
+         $event = $observer->getEvent();
+         /** @var Invoice $invoice */
+         $invoice = $event->getInvoice();
+-        /** @var \Magento\Sales\Model\Order $order */
++        /** @var Order $order */
+         $order = $invoice->getOrder();
+         $orderPaid = false;
+ 
+@@ -84,25 +85,40 @@ class GenerateGiftCardAccountsInvoice implements ObserverInterface
+             $orderPaid = true;
+         }
+ 
+-        /** @var Item $orderItem */
+-        foreach ($order->getAllItems() as $orderItem) {
+-            if ($orderItem->getProductType() !== ProductGiftCard::TYPE_GIFTCARD) {
+-                continue;
+-            }
+-
++        /** @var Item $giftCardItem */
++        foreach ($this->getGiftCardOrderItems($order) as $giftCardItem) {
+             if ($orderPaid) {
+-                $qty = (int)$orderItem->getQtyInvoiced();
++                $qty = (int)$giftCardItem->getQtyInvoiced();
+             } else {
+-                $qty = $this->getInvoicedOrderItemQty($invoice, $orderItem);
++                $qty = $this->getInvoicedOrderItemQty($invoice, $giftCardItem);
+             }
+ 
+-            $options = $orderItem->getProductOptions();
+-            if ($qty > 0) {
+-                $options['giftcard_paid_invoice_items'][] = $orderItem->getItemId();
++            $options = $giftCardItem->getProductOptions();
++            $qtyGiftcardCodes = isset($options['giftcard_created_codes'])
++                ? count($options['giftcard_created_codes'])
++                : 0;
++            if ($qtyGiftcardCodes < (int)$giftCardItem->getQtyInvoiced()) {
++                $options['giftcard_paid_invoice_items'][] = $giftCardItem->getItemId();
++                $this->accountGenerator->generate($giftCardItem, $qty, $options);
+             }
++        }
++    }
+ 
+-            $this->accountGenerator->generate($orderItem, $qty, $options);
++    /**
++     * Return only gift card items from order
++     *
++     * @param Order $order
++     * @return array
++     */
++    private function getGiftCardOrderItems(Order $order): array
++    {
++        $items = [];
++        foreach ($order->getAllItems() as $orderItem) {
++            if ($orderItem->getProductType() === ProductGiftCard::TYPE_GIFTCARD) {
++                $items[] = $orderItem;
++            }
+         }
++        return $items;
+     }
+ 
+     /**

--- a/patches/os/MDVA-26694__fix_product_and_catalog_cache_expiration_daily__2.3.1.patch
+++ b/patches/os/MDVA-26694__fix_product_and_catalog_cache_expiration_daily__2.3.1.patch
@@ -1,0 +1,168 @@
+diff --git a/vendor/magento/module-catalog-rule/Cron/DailyCatalogUpdate.php b/vendor/magento/module-catalog-rule/Cron/DailyCatalogUpdate.php
+index 7f584fb1154..116a4529a8e 100644
+--- a/vendor/magento/module-catalog-rule/Cron/DailyCatalogUpdate.php
++++ b/vendor/magento/module-catalog-rule/Cron/DailyCatalogUpdate.php
+@@ -6,19 +6,34 @@
+ 
+ namespace Magento\CatalogRule\Cron;
+ 
++use Magento\CatalogRule\Model\Indexer\PartialIndex;
++use Magento\CatalogRule\Model\Indexer\Rule\RuleProductProcessor;
++
++/**
++ * Daily update catalog price rule by cron
++ */
+ class DailyCatalogUpdate
+ {
+     /**
+-     * @var \Magento\CatalogRule\Model\Indexer\Rule\RuleProductProcessor
++     * @var RuleProductProcessor
+      */
+     protected $ruleProductProcessor;
+ 
+     /**
+-     * @param \Magento\CatalogRule\Model\Indexer\Rule\RuleProductProcessor $ruleProductProcessor
++     * @var PartialIndex
+      */
+-    public function __construct(\Magento\CatalogRule\Model\Indexer\Rule\RuleProductProcessor $ruleProductProcessor)
+-    {
++    private $partialIndex;
++
++    /**
++     * @param RuleProductProcessor $ruleProductProcessor
++     * @param PartialIndex $partialIndex
++     */
++    public function __construct(
++        RuleProductProcessor $ruleProductProcessor,
++        PartialIndex $partialIndex
++    ) {
+         $this->ruleProductProcessor = $ruleProductProcessor;
++        $this->partialIndex = $partialIndex;
+     }
+ 
+     /**
+@@ -31,6 +46,8 @@ class DailyCatalogUpdate
+      */
+     public function execute()
+     {
+-        $this->ruleProductProcessor->markIndexerAsInvalid();
++        $this->ruleProductProcessor->isIndexerScheduled()
++            ? $this->partialIndex->partialUpdateCatalogRuleProductPrice()
++            : $this->ruleProductProcessor->markIndexerAsInvalid();
+     }
+ }
+diff --git a/vendor/magento/module-catalog-rule/Model/Indexer/PartialIndex.php b/vendor/magento/module-catalog-rule/Model/Indexer/PartialIndex.php
+new file mode 100644
+index 00000000000..12a77f81826
+--- /dev/null
++++ b/vendor/magento/module-catalog-rule/Model/Indexer/PartialIndex.php
+@@ -0,0 +1,97 @@
++<?php
++/**
++ * Copyright © Magento, Inc. All rights reserved.
++ * See COPYING.txt for license details.
++ */
++declare(strict_types=1);
++
++namespace Magento\CatalogRule\Model\Indexer;
++
++use Magento\Framework\DB\Adapter\AdapterInterface;
++use Magento\Framework\App\ResourceConnection;
++
++/**
++ * Catalog rule partial index
++ *
++ * This class triggers the dependent index "catalog_product_price",
++ * and the cache is cleared only for the matched products for partial indexing.
++ */
++class PartialIndex
++{
++    /**
++     * @var ResourceConnection
++     */
++    private $resource;
++
++    /**
++     * @var AdapterInterface
++     */
++    private $connection;
++
++    /**
++     * @var IndexBuilder
++     */
++    private $indexBuilder;
++
++    /**
++     * @param ResourceConnection $resource
++     * @param IndexBuilder $indexBuilder
++     */
++    public function __construct(
++        ResourceConnection $resource,
++        IndexBuilder $indexBuilder
++    ) {
++        $this->resource = $resource;
++        $this->connection = $resource->getConnection();
++        $this->indexBuilder = $indexBuilder;
++    }
++
++    /**
++     * Synchronization replica table with original table "catalogrule_product_price"
++     *
++     * Used replica table for correctly working MySQL trigger
++     *
++     * @return void
++     */
++    public function partialUpdateCatalogRuleProductPrice(): void
++    {
++        $this->indexBuilder->reindexFull();
++        $indexTableName = $this->resource->getTableName('catalogrule_product_price');
++        $select = $this->connection->select()->from(
++            ['crp' => $indexTableName],
++            'product_id'
++        );
++        $selectFields = $this->connection->select()->from(
++            ['crp' => $indexTableName],
++            [
++                'rule_date',
++                'customer_group_id',
++                'product_id',
++                'rule_price',
++                'website_id',
++                'latest_start_date',
++                'earliest_end_date',
++            ]
++        );
++        $where = ['product_id' .' NOT IN (?)' => $select];
++        //remove products that are no longer used in indexing
++        $this->connection->delete($this->resource->getTableName('catalogrule_product_price_replica'), $where);
++        //add updated products to indexing
++        $this->connection->query(
++            $this->connection->insertFromSelect(
++                $selectFields,
++                $this->resource->getTableName('catalogrule_product_price_replica'),
++                [
++                    'rule_date',
++                    'customer_group_id',
++                    'product_id',
++                    'rule_price',
++                    'website_id',
++                    'latest_start_date',
++                    'earliest_end_date',
++                ],
++                AdapterInterface::INSERT_ON_DUPLICATE
++            )
++        );
++    }
++}
+diff --git a/vendor/magento/module-catalog-rule/etc/mview.xml b/vendor/magento/module-catalog-rule/etc/mview.xml
+index 35efe33461a..984215d66db 100644
+--- a/vendor/magento/module-catalog-rule/etc/mview.xml
++++ b/vendor/magento/module-catalog-rule/etc/mview.xml
+@@ -27,6 +27,7 @@
+     <view id="catalog_product_price" class="Magento\Catalog\Model\Indexer\Product\Price" group="indexer">
+         <subscriptions>
+             <table name="catalogrule_product_price" entity_column="product_id" />
++            <table name="catalogrule_product_price_replica" entity_column="product_id" />
+         </subscriptions>
+     </view>
+ </config>

--- a/patches/os/MDVA-27825__fix_memory_leak_prevent_customer_export__2.3.3.patch
+++ b/patches/os/MDVA-27825__fix_memory_leak_prevent_customer_export__2.3.3.patch
@@ -1,0 +1,43 @@
+diff --git a/vendor/magento/module-eav/Model/Entity/Collection/VersionControl/AbstractCollection.php b/vendor/magento/module-eav/Model/Entity/Collection/VersionControl/AbstractCollection.php
+index 631bfa3c2d2..5ecbf70c246 100644
+--- a/vendor/magento/module-eav/Model/Entity/Collection/VersionControl/AbstractCollection.php
++++ b/vendor/magento/module-eav/Model/Entity/Collection/VersionControl/AbstractCollection.php
+@@ -87,4 +87,15 @@ abstract class AbstractCollection extends \Magento\Eav\Model\Entity\Collection\A
+         $this->entitySnapshot->registerSnapshot($item);
+         return $item;
+     }
++
++    /**
++     * Clear collection
++     *
++     * @return $this
++     */
++    public function clear()
++    {
++        $this->entitySnapshot->clear($this->getNewEmptyItem());
++        return parent::clear();
++    }
+ }
+diff --git a/vendor/magento/framework/Model/ResourceModel/Db/VersionControl/Snapshot.php b/vendor/magento/framework/Model/ResourceModel/Db/VersionControl/Snapshot.php
+index 095b5accda7..a287fa5e1af 100644
+--- a/vendor/magento/framework/Model/ResourceModel/Db/VersionControl/Snapshot.php
++++ b/vendor/magento/framework/Model/ResourceModel/Db/VersionControl/Snapshot.php
+@@ -72,4 +72,18 @@ class Snapshot
+ 
+         return false;
+     }
++
++    /**
++     * Clear snapshot data
++     *
++     * @param \Magento\Framework\DataObject|null $entity
++     */
++    public function clear(\Magento\Framework\DataObject $entity = null)
++    {
++        if ($entity !== null) {
++            $this->snapshotData[get_class($entity)] = [];
++        } else {
++            $this->snapshotData = [];
++        }
++    }
+ }

--- a/patches/os/MDVA-29883__fix_storing_boolean_values_for_custom_attributes_in_Elastic_Search__2.3.4.patch
+++ b/patches/os/MDVA-29883__fix_storing_boolean_values_for_custom_attributes_in_Elastic_Search__2.3.4.patch
@@ -1,0 +1,53 @@
+diff --git a/vendor/magento/module-catalog-search/Model/Indexer/Fulltext/Action/DataProvider.php b/vendor/magento/module-catalog-search/Model/Indexer/Fulltext/Action/DataProvider.php
+index cd2529a8fd7..f5d41983187 100644
+--- a/vendor/magento/module-catalog-search/Model/Indexer/Fulltext/Action/DataProvider.php
++++ b/vendor/magento/module-catalog-search/Model/Indexer/Fulltext/Action/DataProvider.php
+@@ -572,11 +572,11 @@ class DataProvider
+         foreach ($indexData as $entityId => $attributeData) {
+             foreach ($attributeData as $attributeId => $attributeValues) {
+                 $value = $this->getAttributeValue($attributeId, $attributeValues, $storeId);
+-                if (!empty($value)) {
++                if ($value !== null && $value !== false && $value !== '') {
+                     if (!isset($index[$attributeId])) {
+                         $index[$attributeId] = [];
+                     }
+-                        $index[$attributeId][$entityId] = $value;
++                    $index[$attributeId][$entityId] = $value;
+                 }
+             }
+         }
+diff --git a/vendor/magento/module-elasticsearch/Model/Adapter/BatchDataMapper/ProductDataMapper.php b/vendor/magento/module-elasticsearch/Model/Adapter/BatchDataMapper/ProductDataMapper.php
+index 270ca37e2d4..e91282fe174 100644
+--- a/vendor/magento/module-elasticsearch/Model/Adapter/BatchDataMapper/ProductDataMapper.php
++++ b/vendor/magento/module-elasticsearch/Model/Adapter/BatchDataMapper/ProductDataMapper.php
+@@ -195,7 +195,7 @@ class ProductDataMapper implements BatchDataMapperInterface
+         $productAttributes = [];
+ 
+         $retrievedValue = $this->retrieveFieldValue($attributeValues);
+-        if ($retrievedValue) {
++        if ($retrievedValue !== null) {
+             $productAttributes[$attribute->getAttributeCode()] = $retrievedValue;
+ 
+             if ($attribute->getIsSearchable()) {
+@@ -320,7 +320,7 @@ class ProductDataMapper implements BatchDataMapperInterface
+      */
+     private function retrieveFieldValue(array $values)
+     {
+-        $values = \array_filter(\array_unique($values));
++        $values = \array_unique($values);
+ 
+         return count($values) === 1 ? \array_shift($values) : \array_values($values);
+     }
+diff --git a/vendor/magento/module-elasticsearch/SearchAdapter/Filter/Builder/Term.php b/vendor/magento/module-elasticsearch/SearchAdapter/Filter/Builder/Term.php
+index d88c7e53d81..5c8834303c2 100644
+--- a/vendor/magento/module-elasticsearch/SearchAdapter/Filter/Builder/Term.php
++++ b/vendor/magento/module-elasticsearch/SearchAdapter/Filter/Builder/Term.php
+@@ -68,7 +68,7 @@ class Term implements FilterInterface
+             $fieldName .= '.' . $suffix;
+         }
+ 
+-        if ($filter->getValue()) {
++        if ($filter->getValue() !== false) {
+             $operator = is_array($filter->getValue()) ? 'terms' : 'term';
+             $filterQuery []= [
+                 $operator => [

--- a/patches/os/MDVA-30052__customer_data_section_invalidation_logic_improvement__2.3.4-p2.patch
+++ b/patches/os/MDVA-30052__customer_data_section_invalidation_logic_improvement__2.3.4-p2.patch
@@ -1,0 +1,101 @@
+diff --git a/vendor/magento/module-customer/CustomerData/SectionConfigConverter.php b/vendor/magento/module-customer/CustomerData/SectionConfigConverter.php
+index 5f4bbb03d39..c9a93c708e3 100644
+--- a/vendor/magento/module-customer/CustomerData/SectionConfigConverter.php
++++ b/vendor/magento/module-customer/CustomerData/SectionConfigConverter.php
+@@ -5,6 +5,9 @@
+  */
+ namespace Magento\Customer\CustomerData;
+ 
++/**
++ * Class that receives xml merged source and process it.
++ */
+ class SectionConfigConverter implements \Magento\Framework\Config\ConverterInterface
+ {
+     /**
+@@ -13,7 +16,7 @@ class SectionConfigConverter implements \Magento\Framework\Config\ConverterInter
+     const INVALIDATE_ALL_SECTIONS_MARKER = '*';
+ 
+     /**
+-     * {@inheritdoc}
++     * @inheritdoc
+      */
+     public function convert($source)
+     {
+@@ -21,10 +24,18 @@ class SectionConfigConverter implements \Magento\Framework\Config\ConverterInter
+         foreach ($source->getElementsByTagName('action') as $action) {
+             $actionName = strtolower($action->getAttribute('name'));
+             foreach ($action->getElementsByTagName('section') as $section) {
+-                $sections[$actionName][] = strtolower($section->getAttribute('name'));
++                $sectionName = strtolower($section->getAttribute('name'));
++
++                if ($sectionName === self::INVALIDATE_ALL_SECTIONS_MARKER) {
++                    $sections[$actionName] = [];
++                    $sections[$actionName][] = self::INVALIDATE_ALL_SECTIONS_MARKER;
++                    break;
++                } else {
++                    $sections[$actionName][] = $sectionName;
++                }
+             }
+             if (!isset($sections[$actionName])) {
+-                $sections[$actionName] = self::INVALIDATE_ALL_SECTIONS_MARKER;
++                $sections[$actionName][] = self::INVALIDATE_ALL_SECTIONS_MARKER;
+             }
+         }
+         return [
+diff --git a/vendor/magento/module-customer/etc/frontend/sections.xml b/vendor/magento/module-customer/etc/frontend/sections.xml
+index 7938f28590c..e6a45dfdeaa 100644
+--- a/vendor/magento/module-customer/etc/frontend/sections.xml
++++ b/vendor/magento/module-customer/etc/frontend/sections.xml
+@@ -7,10 +7,18 @@
+ -->
+ <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Customer:etc/sections.xsd">
+-    <action name="customer/account/logout"/>
+-    <action name="customer/account/loginPost"/>
+-    <action name="customer/account/createPost"/>
+-    <action name="customer/account/editPost"/>
++    <action name="customer/account/logout">
++        <section name="*"/>
++    </action>
++    <action name="customer/account/loginPost">
++        <section name="*"/>
++    </action>
++    <action name="customer/account/createPost">
++        <section name="*"/>
++    </action>
++    <action name="customer/account/editPost">
++        <section name="*"/>
++    </action>
+     <action name="customer/ajax/login">
+         <section name="checkout-data"/>
+         <section name="cart"/>
+diff --git a/vendor/magento/module-directory/etc/frontend/sections.xml b/vendor/magento/module-directory/etc/frontend/sections.xml
+index a2bc5696abf..48d63ec82d9 100644
+--- a/vendor/magento/module-directory/etc/frontend/sections.xml
++++ b/vendor/magento/module-directory/etc/frontend/sections.xml
+@@ -7,5 +7,7 @@
+ -->
+ <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Customer:etc/sections.xsd">
+-    <action name="directory/currency/switch"/>
++    <action name="directory/currency/switch">
++        <section name="*"/>
++    </action>
+ </config>
+diff --git a/vendor/magento/module-store/etc/frontend/sections.xml b/vendor/magento/module-store/etc/frontend/sections.xml
+index b7dbfe40526..85f3627e05c 100644
+--- a/vendor/magento/module-store/etc/frontend/sections.xml
++++ b/vendor/magento/module-store/etc/frontend/sections.xml
+@@ -7,6 +7,10 @@
+ -->
+ <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Customer:etc/sections.xsd">
+-    <action name="stores/store/switch"/>
+-    <action name="stores/store/switchrequest"/>
++    <action name="stores/store/switch">
++        <section name="*"/>
++    </action>
++    <action name="stores/store/switchrequest">
++        <section name="*"/>
++    </action>
+ </config>

--- a/patches/os/MDVA-30131__fix_storing_boolean_values_for_custom_attributes_in_Elastic_Search__2.3.4.patch
+++ b/patches/os/MDVA-30131__fix_storing_boolean_values_for_custom_attributes_in_Elastic_Search__2.3.4.patch
@@ -17,10 +17,10 @@ index cd2529a8fd7..f5d41983187 100644
              }
          }
 diff --git a/vendor/magento/module-elasticsearch/Model/Adapter/BatchDataMapper/ProductDataMapper.php b/vendor/magento/module-elasticsearch/Model/Adapter/BatchDataMapper/ProductDataMapper.php
-index 270ca37e2d4..e91282fe174 100644
+index 67898d021d7..a3cb8dfd8f2 100644
 --- a/vendor/magento/module-elasticsearch/Model/Adapter/BatchDataMapper/ProductDataMapper.php
 +++ b/vendor/magento/module-elasticsearch/Model/Adapter/BatchDataMapper/ProductDataMapper.php
-@@ -195,7 +195,7 @@ class ProductDataMapper implements BatchDataMapperInterface
+@@ -208,7 +208,7 @@ class ProductDataMapper implements BatchDataMapperInterface
          $productAttributes = [];
  
          $retrievedValue = $this->retrieveFieldValue($attributeValues);
@@ -29,15 +29,17 @@ index 270ca37e2d4..e91282fe174 100644
              $productAttributes[$attribute->getAttributeCode()] = $retrievedValue;
  
              if ($attribute->getIsSearchable()) {
-@@ -320,7 +320,7 @@ class ProductDataMapper implements BatchDataMapperInterface
+@@ -340,8 +340,8 @@ class ProductDataMapper implements BatchDataMapperInterface
       */
      private function retrieveFieldValue(array $values)
      {
 -        $values = \array_filter(\array_unique($values));
-+        $values = \array_unique($values);
++        $values = array_unique($values);
  
-         return count($values) === 1 ? \array_shift($values) : \array_values($values);
+-        return count($values) === 1 ? \array_shift($values) : \array_values($values);
++        return count($values) === 1 ? array_shift($values) : array_values($values);
      }
+ }
 diff --git a/vendor/magento/module-elasticsearch/SearchAdapter/Filter/Builder/Term.php b/vendor/magento/module-elasticsearch/SearchAdapter/Filter/Builder/Term.php
 index d88c7e53d81..5c8834303c2 100644
 --- a/vendor/magento/module-elasticsearch/SearchAdapter/Filter/Builder/Term.php


### PR DESCRIPTION
### Release Note

| Patch location  | Description |
| ------------- | ------------- |
| os/MDVA-30052__customer_data_section_invalidation_logic_improvement__2.3.4-p2.patch  | Customer data section invalidation logic has been improved. This release introduces a new way of invalidating all customer sections data that avoids a known issue with local storage when custom `sections.xml` invalidations are active. (Previously, private content (local storage) was not correctly populated when you had a custom *etc/frontend/sections.xml* with action invalidations). |
| os/MDVA-26694__fix_product_and_catalog_cache_expiration_daily__2.3.1.patch | Patch Summary: Product and catalog caches will expire as scheduled. Previously, caches expire daily, as сron runs the “catalogrule_apply_all” task once a day which re-indexes all the catalog rules and its dependent indexers and clears the cache for all products and categories.  |
| os/MDVA-30131__fix_storing_boolean_values_for_custom_attributes_in_Elastic_Search__2.3.4.patch | Code was not storing false values for custom attributes in Elastic Search, so filter was possible using "No" for boolean attributes using layered navigation. To address that, some boolean checks have been replaces for null checks, and an array_filter call has been erased completely as no callback function was provided in it, thus always returning false as "all entries of array equal to FALSE (see converting to boolean) will be removed". |
| os/MDVA-27825__fix_memory_leak_prevent_customer_export__2.3.3.patch | Big data customer export issue. Memory leak prevented by adding clearing of Customer objects in \Magento\Framework\Model\ResourceModel\Db\VersionControl\Snapshot class  |
| commerce/MDVA-29085__fix_email_confirmation_after_company_created_via_API__2.3.5-p1.patch | No new company email received when a company it’s created by API |
| commerce/MDVA-29835__two_gift_card_codes_can_be_seen_for_the_order__2.3.4-p2.patch | Gift Card code doubling on orders |
| commerce/MDVA-29344__fix_page_builder_hangs_after_text_copying__2.3.5-p1.patch | Page builder hangs after copying text from a header element to a text element |



### Fixed Issues
1. https://jira.corp.magento.com/browse/MDVA-30052
2. https://jira.corp.magento.com/browse/MDVA-26694
3. https://jira.corp.magento.com/browse/MDVA-30131
4. https://jira.corp.magento.com/browse/MDVA-27825
5. https://jira.corp.magento.com/browse/MDVA-29085
6. https://jira.corp.magento.com/browse/MDVA-29835
7. https://jira.corp.magento.com/browse/MDVA-29344
