### PR TITLE
1.0.4 release

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -195,7 +195,7 @@
   "MDVA-29965": {
     "magento/magento2-base": {
       "Fixes the issue where customers get Invalid Form Key error when adding a product to the cart.": {
-        ">=2.3.3 <2.4.2": {
+        ">=2.3.3 <2.4.0": {
           "file": "os/MDVA-29965_fixes_invalid_form_key_error_when_adding_to_cart_before_page_fully_refreshes_2.3.5-p1.patch"
         }
       }

--- a/patches.json
+++ b/patches.json
@@ -50,7 +50,7 @@
   },
   "MDVA-27825": {
     "magento/magento2-base": {
-      "Fixes an issue where exporting of big amounts of data failed because of memory leak.": {
+      "Fixes the issue where exporting of big amounts of data failed because of memory leak.": {
         ">=2.3.0 <=2.3.5-p2 || 2.4.0": {
           "file": "os/MDVA-27825__fix_memory_leak_prevent_customer_export__2.3.3.patch"
         }
@@ -59,7 +59,7 @@
   },
   "MDVA-29085": {
     "magento/magento2-b2b-base": {
-      "Fixes a B2B issue where no required new company emails are sent out if a company is created by API.": {
+      "Fixes the B2B issue where no required new company emails are sent out if a company is created by API.": {
         ">=1.1.0 <=1.1.5-p1": {
           "file": "commerce/MDVA-29085__fix_email_confirmation_after_company_created_via_API__2.3.5-p1.patch"
         }
@@ -68,7 +68,7 @@
   },
   "MDVA-29835": {
     "magento/magento2-ee-base": {
-      "Fixes an issue where gift card orders contained two codes instead one.": {
+      "Fixes the issue where gift card orders contained two codes instead one.": {
         ">2.3.1 <=2.3.5-p2 || 2.4.0": {
           "file": "commerce/MDVA-29835__two_gift_card_codes_can_be_seen_for_the_order__2.3.4-p2.patch"
         }
@@ -77,7 +77,7 @@
   },
   "MDVA-29344": {
     "magento/module-page-builder": {
-      "Fixes an issue where Page Builder gets stuck after copying text from a header element to a text element.": {
+      "Fixes the issue where Page Builder gets stuck after copying text from a header element to a text element.": {
         ">=1.3.0 <=1.3.2 || 1.4.0": {
           "file": "commerce/MDVA-29344__fix_page_builder_hangs_after_text_copying__2.3.5-p1.patch"
         }
@@ -86,7 +86,7 @@
   },
   "MC-35514": {
     "magento/magento2-base": {
-      "Fixes an issue with creating a shipping label and adding ordered products to a package in the Create Packages modal window.": {
+      "Fixes the issue with creating a shipping label and adding ordered products to a package in the Create Packages modal window.": {
         "2.4.0": {
           "file": "os/MC-35514__fixes_issue_with_shipping_label_creation__2.4.0.patch"
         }
@@ -95,7 +95,7 @@
   },
   "MC-35984": {
     "magento/magento2-ee-base": {
-      "Fixes issue with the broken Returns page after creating a shipping label for RMA": {
+      "Fixes the issue with the broken Returns page after creating a shipping label for RMA": {
         "2.4.0": {
           "file": "commerce/MC-35984__fixes_issue_in_rma_edit_page_with_shipping_label__2.4.0.patch"
         }
@@ -113,7 +113,7 @@
   },
   "MDVA-30106": {
     "magento/magento2-base": {
-      "Fixes an issue where during checkout payments are not loaded with “Cannot read property ‘length’ of null ” error in JS console.": {
+      "Fixes the issue where during checkout, payments are not loaded with “Cannot read property ‘length’ of null ” error in JS console.": {
         ">=2.3.0 <=2.4.0": {
           "file": "os/MDVA-30106__fix_validation_for_possible_null_objects_on_validation_rules__2.3.4.patch"
         }
@@ -123,7 +123,7 @@
   "MDVA-28656": {
     "magento/magento2-base": {
       "Fixes the issue where if an order was placed with no payment information required (for example, with 100% discount) and an invoice was created for the order, the order status changes to Closed instead of Complete.": {
-        ">=2.3.1 <=2.4.0": {
+        ">=2.3.1 <2.3.6 || 2.4.0": {
           "file": "os/MDVA-28656__fixes_order_status_issue_when_invoicing_zero_payment_orders__2.3.5-p1.patch"
         }
       }
@@ -156,7 +156,6 @@
       }
     }
   },
-
   "MDVA-30164": {
     "magento/magento2-base": {
       "Fixes the issue where customers records cannot be exported from the Customers grid, if custom customer attributes exist.": {
@@ -195,7 +194,7 @@
   },
   "MDVA-29965": {
     "magento/magento2-base": {
-      "Fixed the issue when Invalid Form Key error when adding to cart before page fully refreshes": {
+      "Fixes the issue where customers get Invalid Form Key error when adding a product to the cart.": {
         ">=2.3.3 <=2.3.5-p2": {
           "file": "os/MDVA-29965_fixes_invalid_form_key_error_when_adding_to_cart_before_page_fully_refreshes_2.3.5-p1.patch"
         }
@@ -218,9 +217,7 @@
           "file": "os/MDVA-22469_fixes_page_builder_css_and_js_not_loading_2.3.3.patch"
         }
       }
-    }
-  },
-  "MDVA-22469": {
+    },
     "magento/module-page-builder": {
       "Fixes the issue where after upgrading to Magento 2.3.3, Page Builder is not working in the Admin panel and some JS and CSS files are not loading.": {
         ">=1.0.3 <=1.1.1": {

--- a/patches.json
+++ b/patches.json
@@ -33,7 +33,7 @@
   "MDVA-26694": {
     "magento/magento2-base": {
       "Fixes the issue with product and catalog caches expiring daily, though being scheduled to expire differently.": {
-        ">=2.3.0 <=2.3.5-p2 || 2.4.0": {
+        ">=2.3.0 <2.3.6 || 2.4.0": {
           "file": "os/MDVA-26694__fix_product_and_catalog_cache_expiration_daily__2.3.1.patch"
         }
       }
@@ -42,7 +42,7 @@
   "MDVA-30131": {
     "magento/magento2-base": {
       "Fixes the issue with layered navigation, where the 'No' value for boolean type product attributes was not included in layered navigation if Elasticsearch was used as a search engine.": {
-        ">=2.3.4 <=2.3.5-p2 || 2.4.0": {
+        ">=2.3.4 <2.3.6 || 2.4.0": {
           "file": "os/MDVA-30131__fix_storing_boolean_values_for_custom_attributes_in_Elastic_Search__2.3.4.patch"
         }
       }
@@ -51,7 +51,7 @@
   "MDVA-27825": {
     "magento/magento2-base": {
       "Fixes the issue where exporting of big amounts of data failed because of memory leak.": {
-        ">=2.3.0 <=2.3.5-p2 || 2.4.0": {
+        ">=2.3.0 <2.4.1": {
           "file": "os/MDVA-27825__fix_memory_leak_prevent_customer_export__2.3.3.patch"
         }
       }
@@ -60,7 +60,7 @@
   "MDVA-29085": {
     "magento/magento2-b2b-base": {
       "Fixes the B2B issue where no required new company emails are sent out if a company is created by API.": {
-        ">=1.1.0 <=1.1.5-p1": {
+        ">=1.1.0 <1.2.2": {
           "file": "commerce/MDVA-29085__fix_email_confirmation_after_company_created_via_API__2.3.5-p1.patch"
         }
       }
@@ -69,7 +69,7 @@
   "MDVA-29835": {
     "magento/magento2-ee-base": {
       "Fixes the issue where gift card orders contained two codes instead one.": {
-        ">2.3.1 <=2.3.5-p2 || 2.4.0": {
+        ">2.3.1 <2.4.2": {
           "file": "commerce/MDVA-29835__two_gift_card_codes_can_be_seen_for_the_order__2.3.4-p2.patch"
         }
       }
@@ -78,7 +78,7 @@
   "MDVA-29344": {
     "magento/module-page-builder": {
       "Fixes the issue where Page Builder gets stuck after copying text from a header element to a text element.": {
-        ">=1.3.0 <=1.3.2 || 1.4.0": {
+        ">= 1.3.0 <=1.4.0": {
           "file": "commerce/MDVA-29344__fix_page_builder_hangs_after_text_copying__2.3.5-p1.patch"
         }
       }
@@ -86,8 +86,8 @@
   },
   "MC-35514": {
     "magento/magento2-base": {
-      "Fixes the issue with creating a shipping label and adding ordered products to a package in the Create Packages modal window.": {
-        "2.4.0": {
+      "Fixes the issue where merchants could not add ordered products to a package from the Admin Create Package page and save the package.": {
+        ">=2.4.0 <2.4.1": {
           "file": "os/MC-35514__fixes_issue_with_shipping_label_creation__2.4.0.patch"
         }
       }
@@ -95,8 +95,8 @@
   },
   "MC-35984": {
     "magento/magento2-ee-base": {
-      "Fixes the issue with the broken Returns page after creating a shipping label for RMA": {
-        "2.4.0": {
+      "Fixes the issue where merchants could not interact with any page elements on the Returns page after creating a shipping label for a Return Merchandise Authorization (RMA).": {
+        ">=2.4.0 <2.4.1": {
           "file": "commerce/MC-35984__fixes_issue_in_rma_edit_page_with_shipping_label__2.4.0.patch"
         }
       }
@@ -114,7 +114,7 @@
   "MDVA-30106": {
     "magento/magento2-base": {
       "Fixes the issue where during checkout, payments are not loaded with “Cannot read property ‘length’ of null ” error in JS console.": {
-        ">=2.3.0 <=2.4.0": {
+        "^2.3.0": {
           "file": "os/MDVA-30106__fix_validation_for_possible_null_objects_on_validation_rules__2.3.4.patch"
         }
       }
@@ -123,7 +123,7 @@
   "MDVA-28656": {
     "magento/magento2-base": {
       "Fixes the issue where if an order was placed with no payment information required (for example, with 100% discount) and an invoice was created for the order, the order status changes to Closed instead of Complete.": {
-        ">=2.3.1 <2.3.6 || 2.4.0": {
+        ">=2.3.1 <2.3.6 || >=2.4.0 <2.4.2": {
           "file": "os/MDVA-28656__fixes_order_status_issue_when_invoicing_zero_payment_orders__2.3.5-p1.patch"
         }
       }
@@ -141,7 +141,7 @@
   "MDVA-30123": {
     "magento/magento2-base": {
       "Fixes the issue where attribute option labels are not translated correctly for GraphQL queries.": {
-        ">=2.3.4 <=2.4.0": {
+        ">=2.3.4 <2.4.2": {
           "file": "os/MDVA-30123__fixes_attribute_option_labels_translation_for_graphql_queries__2.3.4.patch"
         }
       }
@@ -150,7 +150,7 @@
   "MDVA-29996": {
     "magento/magento2-ee-base": {
       "Fixes the issue where after enabling category permission, the category page is not getting cached by Full Page Cache.": {
-        ">=2.3.3 <=2.4.0": {
+        ">=2.3.3 <2.4.2": {
           "file": "commerce/MDVA-29996__fixes_page_cache_identifier_with_enabled_category_permissions_and_fpc__2.3.3.patch"
         }
       }
@@ -159,7 +159,7 @@
   "MDVA-30164": {
     "magento/magento2-base": {
       "Fixes the issue where customers records cannot be exported from the Customers grid, if custom customer attributes exist.": {
-        ">=2.3.1 <=2.4.0": {
+        ">=2.3.1 <2.4.2": {
           "file": "os/MDVA-30164__fixes_customer_export_when_custom_customer_attribute_exists__2.3.2.patch"
         }
       }
@@ -168,7 +168,7 @@
   "MDVA-30444": {
     "magento/magento2-base": {
       "Fixes the issue where no confirmation email is sent for orders placed using GraphQL.": {
-        ">=2.3.0 <=2.4.0": {
+        ">=2.3.0 <2.4.1": {
           "file": "os/MDVA-30444__fixes_confirmation_email_not_sent_with_orders_placed_using_graphql__2.3.5-p1.patch"
         }
       }
@@ -186,7 +186,7 @@
   "MDVA-30232": {
     "magento/magento2-base": {
       "Fixes the issue where it is not possible to re-order if the original order contains a gift card.": {
-        ">=2.3.1 <=2.4.0": {
+        ">=2.3.1 <2.4.1": {
           "file": "os/MDVA-30232__fixes_issue_with_re-order_when_order_contains_giftcard__2.3.5-p1.patch"
         }
       }
@@ -195,7 +195,7 @@
   "MDVA-29965": {
     "magento/magento2-base": {
       "Fixes the issue where customers get Invalid Form Key error when adding a product to the cart.": {
-        ">=2.3.3 <=2.3.5-p2": {
+        ">=2.3.3 <2.4.2": {
           "file": "os/MDVA-29965_fixes_invalid_form_key_error_when_adding_to_cart_before_page_fully_refreshes_2.3.5-p1.patch"
         }
       }
@@ -204,7 +204,7 @@
   "MDVA-30008": {
     "magento/magento2-b2b-base": {
       "Fixes the B2B issue where it is not possible to place orders through Admin API for a product which is in a public catalog.": {
-        ">=1.1.1 <=1.1.5-p1 || 1.2.0": {
+        ">=1.1.1 <1.2.2": {
           "file": "commerce/MDVA-30008_fixes_order_placement_via_admin_api_for_public_catalog_products_2.3.3.patch"
         }
       }

--- a/patches.json
+++ b/patches.json
@@ -60,7 +60,7 @@
   "MDVA-29085": {
     "magento/magento2-b2b-base": {
       "Fixes the B2B issue where no required new company emails are sent out if a company is created by API.": {
-        ">=1.1.0 <1.2.2": {
+        ">=1.1.0 <=1.1.5-p1": {
           "file": "commerce/MDVA-29085__fix_email_confirmation_after_company_created_via_API__2.3.5-p1.patch"
         }
       }

--- a/patches.json
+++ b/patches.json
@@ -101,5 +101,132 @@
         }
       }
     }
+  },
+  "MDVA-30195": {
+    "magento/magento2-base": {
+      "Fixes the issue where cron jobs fail if database name is too long, resulting in categories not being updated on the frontend.": {
+        ">=2.3.1 <=2.3.4-p2": {
+          "file": "os/MDVA-30195__fix_to_handle_long_database_names__2.3.4-p2.patch"
+        }
+      }
+    }
+  },
+  "MDVA-30106": {
+    "magento/magento2-base": {
+      "Fixes an issue where during checkout payments are not loaded with “Cannot read property ‘length’ of null ” error in JS console.": {
+        ">=2.3.0 <=2.4.0": {
+          "file": "os/MDVA-30106__fix_validation_for_possible_null_objects_on_validation_rules__2.3.4.patch"
+        }
+      }
+    }
+  },
+  "MDVA-28656": {
+    "magento/magento2-base": {
+      "Fixes the issue where if an order was placed with no payment information required (for example, with 100% discount) and an invoice was created for the order, the order status changes to Closed instead of Complete.": {
+        ">=2.3.1 <=2.4.0": {
+          "file": "os/MDVA-28656__fixes_order_status_issue_when_invoicing_zero_payment_orders__2.3.5-p1.patch"
+        }
+      }
+    }
+  },
+  "MDVA-30209": {
+    "magento/magento2-base": {
+      "Fixes the issue where the customer group was changed to default if customer updated their account information.": {
+        ">=2.3.0 <=2.3.3-p1": {
+          "file": "os/MDVA-30209__fixes_customer_group_id_during_account_update__2.3.0.patch"
+        }
+      }
+    }
+  },
+  "MDVA-30123": {
+    "magento/magento2-base": {
+      "Fixes the issue where attribute option labels are not translated correctly for GraphQL queries.": {
+        ">=2.3.4 <=2.4.0": {
+          "file": "os/MDVA-30123__fixes_attribute_option_labels_translation_for_graphql_queries__2.3.4.patch"
+        }
+      }
+    }
+  },
+  "MDVA-29996": {
+    "magento/magento2-ee-base": {
+      "Fixes the issue where after enabling category permission, the category page is not getting cached by Full Page Cache.": {
+        ">=2.3.3 <=2.4.0": {
+          "file": "commerce/MDVA-29996__fixes_page_cache_identifier_with_enabled_category_permissions_and_fpc__2.3.3.patch"
+        }
+      }
+    }
+  },
+
+  "MDVA-30164": {
+    "magento/magento2-base": {
+      "Fixes the issue where customers records cannot be exported from the Customers grid, if custom customer attributes exist.": {
+        ">=2.3.1 <=2.4.0": {
+          "file": "os/MDVA-30164__fixes_customer_export_when_custom_customer_attribute_exists__2.3.2.patch"
+        }
+      }
+    }
+  },
+  "MDVA-30444": {
+    "magento/magento2-base": {
+      "Fixes the issue where no confirmation email is sent for orders placed using GraphQL.": {
+        ">=2.3.0 <=2.4.0": {
+          "file": "os/MDVA-30444__fixes_confirmation_email_not_sent_with_orders_placed_using_graphql__2.3.5-p1.patch"
+        }
+      }
+    }
+  },
+  "MDVA-30490": {
+    "magento/magento2-base": {
+      "Fixes the issue where products comparison throws the 500 error page, if one of the products has an empty short description.": {
+        ">=2.3.4 <=2.3.5-p2": {
+          "file": "os/MDVA-30490__fixes_500_error_on_product_comparison_when_having_empty_short_product_description__2.3.5-p2.patch"
+        }
+      }
+    }
+  },
+  "MDVA-30232": {
+    "magento/magento2-base": {
+      "Fixes the issue where it is not possible to re-order if the original order contains a gift card.": {
+        ">=2.3.1 <=2.4.0": {
+          "file": "os/MDVA-30232__fixes_issue_with_re-order_when_order_contains_giftcard__2.3.5-p1.patch"
+        }
+      }
+    }
+  },
+  "MDVA-29965": {
+    "magento/magento2-base": {
+      "Fixed the issue when Invalid Form Key error when adding to cart before page fully refreshes": {
+        ">=2.3.3 <=2.3.5-p2": {
+          "file": "os/MDVA-29965_fixes_invalid_form_key_error_when_adding_to_cart_before_page_fully_refreshes_2.3.5-p1.patch"
+        }
+      }
+    }
+  },
+  "MDVA-30008": {
+    "magento/magento2-b2b-base": {
+      "Fixes the B2B issue where it is not possible to place orders through Admin API for a product which is in a public catalog.": {
+        ">=1.1.1 <=1.1.5-p1 || 1.2.0": {
+          "file": "commerce/MDVA-30008_fixes_order_placement_via_admin_api_for_public_catalog_products_2.3.3.patch"
+        }
+      }
+    }
+  },
+  "MDVA-22469": {
+    "magento/magento2-base": {
+      "Fixes the issue where after upgrading to Magento 2.3.3, Page Builder is not working in the Admin panel and some JS and CSS files are not loading.": {
+        ">=2.3.2-p2 <=2.3.3-p1": {
+          "file": "os/MDVA-22469_fixes_page_builder_css_and_js_not_loading_2.3.3.patch"
+        }
+      }
+    }
+  },
+  "MDVA-22469": {
+    "magento/module-page-builder": {
+      "Fixes the issue where after upgrading to Magento 2.3.3, Page Builder is not working in the Admin panel and some JS and CSS files are not loading.": {
+        ">=1.0.3 <=1.1.1": {
+          "file": "commerce/MDVA-22469_fixes_page_builder_css_and_js_not_loading_2.3.3.patch"
+        }
+      }
+    }
   }
 }

--- a/patches/commerce/MDVA-22469_fixes_page_builder_css_and_js_not_loading_2.3.3.patch
+++ b/patches/commerce/MDVA-22469_fixes_page_builder_css_and_js_not_loading_2.3.3.patch
@@ -1,0 +1,131 @@
+diff --git a/vendor/magento/module-page-builder/Controller/Adminhtml/Stage/Render.php b/vendor/magento/module-page-builder/Controller/Adminhtml/Stage/Render.php
+index c11418a4d..72436bcab 100644
+--- a/vendor/magento/module-page-builder/Controller/Adminhtml/Stage/Render.php
++++ b/vendor/magento/module-page-builder/Controller/Adminhtml/Stage/Render.php
+@@ -7,8 +7,9 @@
+ 
+ namespace Magento\PageBuilder\Controller\Adminhtml\Stage;
+ 
++use Magento\Backend\App\Action\Context;
+ use Magento\Framework\App\Action\HttpGetActionInterface;
+-use Magento\RequireJs\Block\Html\Head\Config;
++use Magento\Framework\View\Result\PageFactory;
+ 
+ /**
+  * Class Render
+@@ -20,30 +21,31 @@ class Render extends \Magento\Backend\App\Action implements HttpGetActionInterfa
+     const ADMIN_RESOURCE = 'Magento_Backend::content';
+ 
+     /**
+-     * Render the RequireJS and Page Builder render blocks without any additional layout
++     * @var \Magento\Framework\View\Result\PageFactory
++     */
++    protected $pageFactory;
++
++    /**
++     * Render constructor.
++     *
++     * @param Context $context
++     * @param PageFactory $pageFactory
++     */
++    public function __construct(
++        Context $context,
++        PageFactory $pageFactory
++    ) {
++        $this->pageFactory = $pageFactory;
++        return parent::__construct($context);
++    }
++
++    /**
++     * Render route
+      *
+-     * @return void
++     * @return \Magento\Framework\App\ResponseInterface|\Magento\Framework\Controller\ResultInterface|mixed
+      */
+     public function execute()
+     {
+-        $layout = $this->_view->getLayout();
+-        $requireJs = $layout->createBlock(
+-            \Magento\Backend\Block\Page\RequireJs::class,
+-            'require.js'
+-        );
+-        $requireJs->setTemplate('Magento_Backend::page/js/require_js.phtml');
+-        /* @var \Magento\PageBuilder\Block\Adminhtml\Stage\Render $renderBlock */
+-        $renderBlock = $layout->createBlock(
+-            \Magento\PageBuilder\Block\Adminhtml\Stage\Render::class,
+-            'stage_render'
+-        );
+-        $renderBlock->setTemplate('Magento_PageBuilder::stage/render.phtml');
+-        $babelPolyfill = $layout->createBlock(
+-            \Magento\PageBuilder\Block\Adminhtml\Html\Head\BabelPolyfill::class,
+-            'pagebuilder.babel.polyfill'
+-        );
+-        $babelPolyfill->setTemplate('Magento_PageBuilder::html/head/babel_polyfill.phtml');
+-        $this->getResponse()->setBody($requireJs->toHtml() . $babelPolyfill->toHtml() . $renderBlock->toHtml());
+-        $this->getResponse()->sendResponse();
++        return $this->pageFactory->create();
+     }
+ }
+diff --git a/vendor/magento/module-page-builder/view/adminhtml/layout/pagebuilder_stage_render.xml b/vendor/magento/module-page-builder/view/adminhtml/layout/pagebuilder_stage_render.xml
+new file mode 100644
+index 000000000..6a95e8e87
+--- /dev/null
++++ b/vendor/magento/module-page-builder/view/adminhtml/layout/pagebuilder_stage_render.xml
+@@ -0,0 +1,25 @@
++<?xml version="1.0"?>
++<!--
++/**
++ * Copyright © Magento, Inc. All rights reserved.
++ * See COPYING.txt for license details.
++ */
++-->
++<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="admin-1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
++    <head>
++        <remove src="extjs/resources/css/ext-all.css"/>
++        <remove src="extjs/resources/css/ytheme-magento.css"/>
++        <remove src="jquery/jstree/themes/default/style.css"/>
++        <remove src="css/styles-old.css"/>
++        <remove src="css/styles.css"/>
++    </head>
++    <body>
++        <referenceContainer name="backend.page" remove="true"/>
++        <referenceContainer name="menu.wrapper" remove="true"/>
++        <referenceContainer name="root">
++            <block name="stage_render" class="Magento\PageBuilder\Block\Adminhtml\Stage\Render" template="Magento_PageBuilder::stage/render.phtml" />
++            <block name="pagebuilder.babel.polyfill" class="Magento\PageBuilder\Block\Adminhtml\Html\Head\BabelPolyfill" template="Magento_PageBuilder::html/head/babel_polyfill.phtml" />
++            <block class="Magento\RequireJs\Block\Html\Head\Config" name="requirejs-config"/>
++        </referenceContainer>
++    </body>
++</page>
+diff --git a/vendor/magento/module-page-builder/view/adminhtml/templates/stage/render.phtml b/vendor/magento/module-page-builder/view/adminhtml/templates/stage/render.phtml
+index c1280e3ff..cd3c853b2 100644
+--- a/vendor/magento/module-page-builder/view/adminhtml/templates/stage/render.phtml
++++ b/vendor/magento/module-page-builder/view/adminhtml/templates/stage/render.phtml
+@@ -6,8 +6,6 @@
+ 
+ /** @var \Magento\PageBuilder\Block\Adminhtml\Stage\Render $block */
+ ?>
+-<script src="<?= $block->escapeUrl($block->getRequireJsUrl()); ?>"></script>
+-<script src="<?= $block->escapeUrl($block->getRequireJsConfigUrl()); ?>"></script>
+ <script>
+     <?php
+     /**
+@@ -19,9 +17,9 @@
+         'map': {
+             '*': {
+                 'text': 'Magento_PageBuilder/js/master-format/render/requirejs/text',
+-                'Magento_PageBuilder/js/events': 'Magento_PageBuilder/js/master-format/render/events',
++                'Magento_PageBuilder/js/events': 'Magento_PageBuilder/js/master-format/render/events'
+             }
+-        },
++        }
+     });
+ 
+     <?php
+@@ -47,4 +45,4 @@
+         listen(<?= /* @noEscape */ $block->getPageBuilderConfig(); ?>);
+     });
+ </script>
+-<div>Page Builder Render Frame</div>
+\ No newline at end of file
++<div>Page Builder Render Frame</div>

--- a/patches/commerce/MDVA-29996__fixes_page_cache_identifier_with_enabled_category_permissions_and_fpc__2.3.3.patch
+++ b/patches/commerce/MDVA-29996__fixes_page_cache_identifier_with_enabled_category_permissions_and_fpc__2.3.3.patch
@@ -1,0 +1,61 @@
+diff --git a/vendor/magento/module-catalog-permissions/Plugin/UpdateCachePlugin.php b/vendor/magento/module-catalog-permissions/Plugin/UpdateCachePlugin.php
+index e1b677405f1..e00f3a603fc 100644
+--- a/vendor/magento/module-catalog-permissions/Plugin/UpdateCachePlugin.php
++++ b/vendor/magento/module-catalog-permissions/Plugin/UpdateCachePlugin.php
+@@ -10,19 +10,15 @@ namespace Magento\CatalogPermissions\Plugin;
+ use Magento\Customer\Model\Session;
+ use Magento\CatalogPermissions\App\ConfigInterface;
+ use Magento\Framework\App\Http\Context as HttpContext;
+-use Magento\Framework\Registry;
+ 
+ /**
+  * Class UpdateCachePlugin to update Context with data
++ *
++ * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
+  */
+ class UpdateCachePlugin
+ {
+     /**
+-     * @var Registry
+-     */
+-    private $coreRegistry;
+-
+-    /**
+      * @var Session
+      */
+     private $customerSession;
+@@ -33,16 +29,13 @@ class UpdateCachePlugin
+     private $permissionsConfig;
+ 
+     /**
+-     * @param Registry $coreRegistry
+      * @param Session $customerSession
+      * @param ConfigInterface $permissionsConfig
+      */
+     public function __construct(
+-        Registry $coreRegistry,
+         Session $customerSession,
+         ConfigInterface $permissionsConfig
+     ) {
+-        $this->coreRegistry = $coreRegistry;
+         $this->customerSession = $customerSession;
+         $this->permissionsConfig = $permissionsConfig;
+     }
+@@ -62,17 +55,11 @@ class UpdateCachePlugin
+             return $result;
+         }
+ 
+-        $category = $this->coreRegistry->registry('current_category');
+         $customerGroupId = $this->customerSession->getCustomerGroupId();
+-
+         if ($customerGroupId) {
+             $result['customer_group'] = $customerGroupId;
+         }
+ 
+-        if ($category && $category->getId()) {
+-            $result['category'] = $category->getId();
+-        }
+-
+         return $result;
+     }
+ }

--- a/patches/commerce/MDVA-30008_fixes_order_placement_via_admin_api_for_public_catalog_products_2.3.3.patch
+++ b/patches/commerce/MDVA-30008_fixes_order_placement_via_admin_api_for_public_catalog_products_2.3.3.patch
@@ -1,0 +1,163 @@
+diff --git a/vendor/magento/module-shared-catalog/Plugin/Quote/Api/ValidateAddProductToCartPlugin.php b/vendor/magento/module-shared-catalog/Plugin/Quote/Api/ValidateAddProductToCartPlugin.php
+index cf50d683e..15d0f7e1f 100644
+--- a/vendor/magento/module-shared-catalog/Plugin/Quote/Api/ValidateAddProductToCartPlugin.php
++++ b/vendor/magento/module-shared-catalog/Plugin/Quote/Api/ValidateAddProductToCartPlugin.php
+@@ -5,7 +5,17 @@
+  */
+ namespace Magento\SharedCatalog\Plugin\Quote\Api;
+ 
++use Magento\Framework\Exception\NoSuchEntityException;
++use Magento\Quote\Api\CartItemRepositoryInterface;
++use Magento\Quote\Api\CartRepositoryInterface;
++use Magento\Quote\Api\Data\CartItemInterface;
++use Magento\SharedCatalog\Api\Data\SharedCatalogInterface;
++use Magento\SharedCatalog\Api\ProductManagementInterface;
++use Magento\SharedCatalog\Api\SharedCatalogManagementInterface;
++use Magento\SharedCatalog\Api\StatusInfoInterface;
++use Magento\SharedCatalog\Model\SharedCatalogLocator;
+ use Magento\Store\Model\ScopeInterface;
++use Magento\Store\Model\StoreManagerInterface;
+ 
+ /**
+  * Denies to add product to cart if SharedCatalog module is active and product is not in a shared catalog.
+@@ -13,50 +23,50 @@ use Magento\Store\Model\ScopeInterface;
+ class ValidateAddProductToCartPlugin
+ {
+     /**
+-     * @var \Magento\SharedCatalog\Api\StatusInfoInterface
++     * @var StatusInfoInterface
+      */
+     private $moduleConfig;
+ 
+     /**
+-     * @var \Magento\Quote\Api\CartRepositoryInterface
++     * @var CartRepositoryInterface
+      */
+     private $quoteRepository;
+ 
+     /**
+-     * @var \Magento\SharedCatalog\Model\SharedCatalogLocator
++     * @var SharedCatalogLocator
+      */
+     private $sharedCatalogLocator;
+ 
+     /**
+-     * @var \Magento\SharedCatalog\Api\SharedCatalogManagementInterface
++     * @var SharedCatalogManagementInterface
+      */
+     private $sharedCatalogManagement;
+ 
+     /**
+-     * @var \Magento\SharedCatalog\Api\ProductManagementInterface
++     * @var ProductManagementInterface
+      */
+     private $sharedCatalogProductManagement;
+ 
+     /**
+-     * @var \Magento\Store\Model\StoreManagerInterface
++     * @var StoreManagerInterface
+      */
+     private $storeManager;
+ 
+     /**
+-     * @param \Magento\SharedCatalog\Api\StatusInfoInterface $moduleConfig
+-     * @param \Magento\Quote\Api\CartRepositoryInterface $quoteRepository
+-     * @param \Magento\SharedCatalog\Model\SharedCatalogLocator $sharedCatalogLocator
+-     * @param \Magento\SharedCatalog\Api\SharedCatalogManagementInterface $sharedCatalogManagement
+-     * @param \Magento\SharedCatalog\Api\ProductManagementInterface $sharedCatalogProductManagement
+-     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
++     * @param StatusInfoInterface $moduleConfig
++     * @param CartRepositoryInterface $quoteRepository
++     * @param SharedCatalogLocator $sharedCatalogLocator
++     * @param SharedCatalogManagementInterface $sharedCatalogManagement
++     * @param ProductManagementInterface $sharedCatalogProductManagement
++     * @param StoreManagerInterface $storeManager
+      */
+     public function __construct(
+-        \Magento\SharedCatalog\Api\StatusInfoInterface $moduleConfig,
+-        \Magento\Quote\Api\CartRepositoryInterface $quoteRepository,
+-        \Magento\SharedCatalog\Model\SharedCatalogLocator $sharedCatalogLocator,
+-        \Magento\SharedCatalog\Api\SharedCatalogManagementInterface $sharedCatalogManagement,
+-        \Magento\SharedCatalog\Api\ProductManagementInterface $sharedCatalogProductManagement,
+-        \Magento\Store\Model\StoreManagerInterface $storeManager
++        StatusInfoInterface $moduleConfig,
++        CartRepositoryInterface $quoteRepository,
++        SharedCatalogLocator $sharedCatalogLocator,
++        SharedCatalogManagementInterface $sharedCatalogManagement,
++        ProductManagementInterface $sharedCatalogProductManagement,
++        StoreManagerInterface $storeManager
+     ) {
+         $this->moduleConfig = $moduleConfig;
+         $this->quoteRepository = $quoteRepository;
+@@ -69,26 +79,30 @@ class ValidateAddProductToCartPlugin
+     /**
+      * Denies to add product to cart if SharedCatalog module is active and product is not in a shared catalog.
+      *
+-     * @param \Magento\Quote\Api\CartItemRepositoryInterface $subject
+-     * @param \Magento\Quote\Api\Data\CartItemInterface $cartItem
++     * @param CartItemRepositoryInterface $subject
++     * @param CartItemInterface $cartItem
+      * @return array
+-     * @throws \Magento\Framework\Exception\NoSuchEntityException
++     * @throws NoSuchEntityException
+      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+      */
+     public function beforeSave(
+-        \Magento\Quote\Api\CartItemRepositoryInterface $subject,
+-        \Magento\Quote\Api\Data\CartItemInterface $cartItem
++        CartItemRepositoryInterface $subject,
++        CartItemInterface $cartItem
+     ) {
+         $website = $this->storeManager->getWebsite()->getId();
+         if ($this->moduleConfig->isActive(ScopeInterface::SCOPE_WEBSITE, $website)) {
+             $quote = $this->quoteRepository->get($cartItem->getQuoteId());
+-            $sharedCatalog = $this->getSharedCatalog($quote->getCustomerGroupId());
+             $sku = $cartItem->getSku();
+ 
+-            if (!$sharedCatalog || !$this->isProductInSharedCatalog($sharedCatalog->getId(), $sku)) {
+-                throw new \Magento\Framework\Exception\NoSuchEntityException(
+-                    __('Requested product doesn\'t exist: %1.', $sku)
+-                );
++            if (!$this->isProductInPublicCatalog($sku)) {
++
++                $sharedCatalog = $this->getSharedCatalog($quote->getCustomerGroupId());
++
++                if (!$sharedCatalog || !$this->isProductInSharedCatalog($sharedCatalog->getId(), $sku)) {
++                    throw new NoSuchEntityException(
++                        __('Requested product doesn\'t exist: %1.', $sku)
++                    );
++                }
+             }
+         }
+ 
+@@ -99,7 +113,7 @@ class ValidateAddProductToCartPlugin
+      * Get shared catalog by customer group id if $customerGroupId is not empty or load public shared catalog.
+      *
+      * @param int $customerGroupId
+-     * @return \Magento\SharedCatalog\Api\Data\SharedCatalogInterface|null
++     * @return SharedCatalogInterface|null
+      */
+     private function getSharedCatalog($customerGroupId)
+     {
+@@ -123,4 +137,21 @@ class ValidateAddProductToCartPlugin
+ 
+         return in_array($sku, $productSkus);
+     }
++
++    /**
++     * Is a product with a given sku assigned to a public catalog
++     *
++     * @param string $sku
++     * @return bool
++     */
++    private function isProductInPublicCatalog($sku): bool
++    {
++        if (!$this->sharedCatalogManagement->isPublicCatalogExist()) {
++            return false;
++        }
++        $publicCatalog = $this->sharedCatalogManagement->getPublicCatalog();
++        $productSkus = $this->sharedCatalogProductManagement->getProducts($publicCatalog->getId());
++
++        return in_array($sku, $productSkus);
++    }
+ }

--- a/patches/os/MDVA-22469_fixes_page_builder_css_and_js_not_loading_2.3.3.patch
+++ b/patches/os/MDVA-22469_fixes_page_builder_css_and_js_not_loading_2.3.3.patch
@@ -1,0 +1,89 @@
+diff --git a/lib/web/mage/requirejs/static.js b/lib/web/mage/requirejs/static.js
+index 237aa0c6a8a..ea005c37cbe 100644
+--- a/lib/web/mage/requirejs/static.js
++++ b/lib/web/mage/requirejs/static.js
+@@ -2,13 +2,66 @@
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
++var storageShim = {
++    _data: {},
++
++    /**
++     * Sets value of the specified item.
++     *
++     * @param {String} key - Key of the property.
++     * @param {*} value - Properties' value.
++     */
++    setItem: function (key, value) {
++        'use strict';
++
++        this._data[key] = value + '';
++    },
++
++    /**
++     * Retrieves specified item.
++     *
++     * @param {String} key - Key of the property to be retrieved.
++     */
++    getItem: function (key) {
++        'use strict';
++
++        return this._data[key];
++    },
++
++    /**
++     * Removes specified item.
++     *
++     * @param {String} key - Key of the property to be removed.
++     */
++    removeItem: function (key) {
++        'use strict';
++
++        delete this._data[key];
++    },
++
++    /**
++     * Removes all items.
++     */
++    clear: function () {
++        'use strict';
++
++        this._data = {};
++    }
++};
++
+ define('buildTools', [
+ ], function () {
+     'use strict';
+ 
+-    var storage = window.localStorage,
++    var storage,
+         storeName = 'buildDisabled';
+ 
++    try {
++        storage = window.localStorage;
++    } catch (e) {
++        storage = storageShim;
++    }
++
+     return {
+         isEnabled: storage.getItem(storeName) === null,
+ 
+@@ -70,9 +123,15 @@ define('statistician', [
+ ], function () {
+     'use strict';
+ 
+-    var storage     = window.localStorage,
++    var storage,
+         stringify   = JSON.stringify.bind(JSON);
+ 
++    try {
++        storage = window.localStorage;
++    } catch (e) {
++        storage = storageShim;
++    }
++
+     /**
+      * Removes duplicated entries of array, returning new one.
+      *

--- a/patches/os/MDVA-28656__fixes_order_status_issue_when_invoicing_zero_payment_orders__2.3.5-p1.patch
+++ b/patches/os/MDVA-28656__fixes_order_status_issue_when_invoicing_zero_payment_orders__2.3.5-p1.patch
@@ -1,0 +1,96 @@
+diff --git a/vendor/magento/module-sales/Model/Order/Invoice/Total/Discount.php b/vendor/magento/module-sales/Model/Order/Invoice/Total/Discount.php
+index acd0d0c67d8..ef7205b3744 100644
+--- a/vendor/magento/module-sales/Model/Order/Invoice/Total/Discount.php
++++ b/vendor/magento/module-sales/Model/Order/Invoice/Total/Discount.php
+@@ -5,13 +5,20 @@
+  */
+ namespace Magento\Sales\Model\Order\Invoice\Total;
+ 
++use Magento\Sales\Model\Order\Invoice;
++
++/**
++ * Discount invoice
++ */
+ class Discount extends AbstractTotal
+ {
+     /**
+-     * @param \Magento\Sales\Model\Order\Invoice $invoice
++     * Collect invoice
++     *
++     * @param Invoice $invoice
+      * @return $this
+      */
+-    public function collect(\Magento\Sales\Model\Order\Invoice $invoice)
++    public function collect(Invoice $invoice)
+     {
+         $invoice->setDiscountAmount(0);
+         $invoice->setBaseDiscountAmount(0);
+@@ -24,14 +31,7 @@ class Discount extends AbstractTotal
+          * So basically if we have invoice with positive discount and it
+          * was not canceled we don't add shipping discount to this one.
+          */
+-        $addShippingDiscount = true;
+-        foreach ($invoice->getOrder()->getInvoiceCollection() as $previousInvoice) {
+-            if ($previousInvoice->getDiscountAmount()) {
+-                $addShippingDiscount = false;
+-            }
+-        }
+-
+-        if ($addShippingDiscount) {
++        if ($this->isShippingDiscount($invoice)) {
+             $totalDiscountAmount = $totalDiscountAmount + $invoice->getOrder()->getShippingDiscountAmount();
+             $baseTotalDiscountAmount = $baseTotalDiscountAmount +
+                 $invoice->getOrder()->getBaseShippingDiscountAmount();
+@@ -71,8 +71,29 @@ class Discount extends AbstractTotal
+         $invoice->setDiscountAmount(-$totalDiscountAmount);
+         $invoice->setBaseDiscountAmount(-$baseTotalDiscountAmount);
+ 
+-        $invoice->setGrandTotal($invoice->getGrandTotal() - $totalDiscountAmount);
+-        $invoice->setBaseGrandTotal($invoice->getBaseGrandTotal() - $baseTotalDiscountAmount);
++        $grandTotal = $invoice->getGrandTotal() - $totalDiscountAmount < 0.0001
++            ? 0 : $invoice->getGrandTotal() - $totalDiscountAmount;
++        $baseGrandTotal = $invoice->getBaseGrandTotal() - $baseTotalDiscountAmount < 0.0001
++            ? 0 : $invoice->getBaseGrandTotal() - $baseTotalDiscountAmount;
++        $invoice->setGrandTotal($grandTotal);
++        $invoice->setBaseGrandTotal($baseGrandTotal);
+         return $this;
+     }
++
++    /**
++     * Checking if shipping discount was added in previous invoices.
++     *
++     * @param Invoice $invoice
++     * @return bool
++     */
++    private function isShippingDiscount(Invoice $invoice): bool
++    {
++        $addShippingDiscount = true;
++        foreach ($invoice->getOrder()->getInvoiceCollection() as $previousInvoice) {
++            if ($previousInvoice->getDiscountAmount()) {
++                $addShippingDiscount = false;
++            }
++        }
++        return $addShippingDiscount;
++    }
+ }
+diff --git a/vendor/magento/module-sales/Model/ResourceModel/Order/Handler/State.php b/vendor/magento/module-sales/Model/ResourceModel/Order/Handler/State.php
+index de15a627583..47395b17afe 100644
+--- a/vendor/magento/module-sales/Model/ResourceModel/Order/Handler/State.php
++++ b/vendor/magento/module-sales/Model/ResourceModel/Order/Handler/State.php
+@@ -9,7 +9,7 @@ namespace Magento\Sales\Model\ResourceModel\Order\Handler;
+ use Magento\Sales\Model\Order;
+ 
+ /**
+- * Class State
++ * Checking order status and adjusting order status before saving
+  */
+ class State
+ {
+@@ -34,6 +34,7 @@ class State
+             if (in_array($currentState, [Order::STATE_PROCESSING, Order::STATE_COMPLETE])
+                 && !$order->canCreditmemo()
+                 && !$order->canShip()
++                && $order->getIsNotVirtual()
+             ) {
+                 $order->setState(Order::STATE_CLOSED)
+                     ->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_CLOSED));

--- a/patches/os/MDVA-29965_fixes_invalid_form_key_error_when_adding_to_cart_before_page_fully_refreshes_2.3.5-p1.patch
+++ b/patches/os/MDVA-29965_fixes_invalid_form_key_error_when_adding_to_cart_before_page_fully_refreshes_2.3.5-p1.patch
@@ -1,0 +1,26 @@
+diff --git a/vendor/magento/module-catalog/view/frontend/templates/product/list.phtml b/vendor/magento/module-catalog/view/frontend/templates/product/list.phtml
+index 461f4ad0d99..4c5caf0bea1 100644
+--- a/vendor/magento/module-catalog/view/frontend/templates/product/list.phtml
++++ b/vendor/magento/module-catalog/view/frontend/templates/product/list.phtml
+@@ -93,7 +93,8 @@ $_helper = $this->helper(Magento\Catalog\Helper\Output::class);
+                                             <?= $block->getBlockHtml('formkey') ?>
+                                             <button type="submit"
+                                                     title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>"
+-                                                    class="action tocart primary">
++                                                    class="action tocart primary"
++                                                    disabled>
+                                                 <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                             </button>
+                                         </form>
+diff --git a/vendor/magento/module-catalog/view/frontend/web/js/catalog-add-to-cart.js b/vendor/magento/module-catalog/view/frontend/web/js/catalog-add-to-cart.js
+index 382b4ef9853..84b67ac5fd4 100644
+--- a/vendor/magento/module-catalog/view/frontend/web/js/catalog-add-to-cart.js
++++ b/vendor/magento/module-catalog/view/frontend/web/js/catalog-add-to-cart.js
+@@ -32,6 +32,7 @@ define([
+             if (this.options.bindSubmit) {
+                 this._bindSubmit();
+             }
++            $(this.options.addToCartButtonSelector).attr('disabled', false);
+         },
+ 
+         /**

--- a/patches/os/MDVA-30106__fix_validation_for_possible_null_objects_on_validation_rules__2.3.4.patch
+++ b/patches/os/MDVA-30106__fix_validation_for_possible_null_objects_on_validation_rules__2.3.4.patch
@@ -1,0 +1,20 @@
+diff --git a/vendor/magento/module-ui/view/base/web/js/lib/validation/rules.js b/vendor/magento/module-ui/view/base/web/js/lib/validation/rules.js
+index 08f67955976..88f2b2508e5 100644
+--- a/vendor/magento/module-ui/view/base/web/js/lib/validation/rules.js
++++ b/vendor/magento/module-ui/view/base/web/js/lib/validation/rules.js
+@@ -60,13 +60,13 @@ define([
+     return _.mapObject({
+         'min_text_length': [
+             function (value, params) {
+-                return _.isUndefined(value) || value.length === 0 || value.length >= +params;
++                return _.isUndefined(value) || _.isNull(value) || value.length === 0 || value.length >= +params;
+             },
+             $.mage.__('Please enter more or equal than {0} symbols.')
+         ],
+         'max_text_length': [
+             function (value, params) {
+-                return !_.isUndefined(value) && value.length <= +params;
++                return _.isUndefined(value) || _.isNull(value) || value.length <= +params;
+             },
+             $.mage.__('Please enter less or equal than {0} symbols.')
+         ],

--- a/patches/os/MDVA-30123__fixes_attribute_option_labels_translation_for_graphql_queries__2.3.4.patch
+++ b/patches/os/MDVA-30123__fixes_attribute_option_labels_translation_for_graphql_queries__2.3.4.patch
@@ -1,0 +1,157 @@
+diff --git a/vendor/magento/module-catalog-graph-ql/DataProvider/Product/LayeredNavigation/AttributeOptionProvider.php b/vendor/magento/module-catalog-graph-ql/DataProvider/Product/LayeredNavigation/AttributeOptionProvider.php
+index 320e0adc29b..576281861d3 100644
+--- a/vendor/magento/module-catalog-graph-ql/DataProvider/Product/LayeredNavigation/AttributeOptionProvider.php
++++ b/vendor/magento/module-catalog-graph-ql/DataProvider/Product/LayeredNavigation/AttributeOptionProvider.php
+@@ -30,11 +30,20 @@ class AttributeOptionProvider
+     private $resourceConnection;
+ 
+     /**
++     * @var \Magento\Catalog\Model\ResourceModel\ProductFactory 
++     */
++    private $productFactory;
++
++    /**
+      * @param ResourceConnection $resourceConnection
+      */
+-    public function __construct(ResourceConnection $resourceConnection)
++    public function __construct(
++        ResourceConnection $resourceConnection,
++        \Magento\Catalog\Model\ResourceModel\ProductFactory $productFactory
++    )
+     {
+         $this->resourceConnection = $resourceConnection;
++        $this->productFactory = $productFactory;
+     }
+ 
+     /**
+@@ -45,14 +54,14 @@ class AttributeOptionProvider
+      * @return array
+      * @throws \Zend_Db_Statement_Exception
+      */
+-    public function getOptions(array $optionIds, array $attributeCodes = []): array
++    public function getOptions(array $optionIds, array $attributeCodes = [], $storeId): array
+     {
+         if (!$optionIds) {
+             return [];
+         }
+ 
+         $connection = $this->resourceConnection->getConnection();
+-        $select = $connection->select()
++        $select = $connection->select()            
+             ->from(
+                 ['a' => $this->resourceConnection->getTableName('eav_attribute')],
+                 [
+@@ -67,24 +76,34 @@ class AttributeOptionProvider
+                 []
+             )
+             ->joinLeft(
++                ['attrlabel' => $this->resourceConnection->getTableName('eav_attribute_label')],
++                'a.attribute_id = attrlabel.attribute_id',
++                [
++                    'store_label' => 'attrlabel.value',
++                    'attribute_store_id' => 'attrlabel.store_id'
++                ]
++            )
++            ->joinLeft(
+                 ['option_value' => $this->resourceConnection->getTableName('eav_attribute_option_value')],
+                 'options.option_id = option_value.option_id',
+                 [
+                     'option_label' => 'option_value.value',
+                     'option_id' => 'option_value.option_id',
++                    'option_store_id' => 'option_value.store_id'
+                 ]
+             );
+ 
+         $select->where('option_value.option_id IN (?)', $optionIds);
+-
++       
++ 
+         if (!empty($attributeCodes)) {
+             $select->orWhere(
+                 'a.attribute_code in (?) AND a.frontend_input = \'boolean\'',
+                 $attributeCodes
+             );
+         }
+-
+-        return $this->formatResult($select);
++            
++        return $this->formatResult($select, $storeId);
+     }
+ 
+     /**
+@@ -94,23 +113,38 @@ class AttributeOptionProvider
+      * @return array
+      * @throws \Zend_Db_Statement_Exception
+      */
+-    private function formatResult(\Magento\Framework\DB\Select $select): array
+-    {
++    private function formatResult(\Magento\Framework\DB\Select $select, $storeId): array
++    {        
+         $statement = $this->resourceConnection->getConnection()->query($select);
+ 
+         $result = [];
++        $poductReource=$this->productFactory->create();
++        
+         while ($option = $statement->fetch()) {
+-            if (!isset($result[$option['attribute_code']])) {
++                
++            if($poductReource->getAttribute($option['attribute_code'])->getStoreLabel($storeId)){
++                $attributeLabel = $poductReource->getAttribute($option['attribute_code'])->getStoreLabel($storeId);    
++            }else{
++                $attributeLabel = $option['attribute_label'];
++            }
++            
++            $attribute = $poductReource->getAttribute($option['attribute_code']);
++            if ($attribute->usesSource()) {
++              $option_Text = $attribute->getSource()->getOptionText($option['option_id']);
++            }            
++          
++            if (!isset($result[$option['attribute_code']])) {              
+                 $result[$option['attribute_code']] = [
+                     'attribute_id' => $option['attribute_id'],
+                     'attribute_code' => $option['attribute_code'],
+-                    'attribute_label' => $option['attribute_label'],
++                    'attribute_label' =>  $attributeLabel,
+                     'options' => [],
+                 ];
+-            }
+-            $result[$option['attribute_code']]['options'][$option['option_id']] = $option['option_label'];
++            }            
++                
++            $result[$option['attribute_code']]['options'][$option['option_id']] = $option_Text;
+         }
+-
++      
+         return $result;
+     }
+ }
+diff --git a/vendor/magento/module-catalog-graph-ql/DataProvider/Product/LayeredNavigation/Builder/Attribute.php b/vendor/magento/module-catalog-graph-ql/DataProvider/Product/LayeredNavigation/Builder/Attribute.php
+index 0ec65c88024..e550de9cb03 100644
+--- a/vendor/magento/module-catalog-graph-ql/DataProvider/Product/LayeredNavigation/Builder/Attribute.php
++++ b/vendor/magento/module-catalog-graph-ql/DataProvider/Product/LayeredNavigation/Builder/Attribute.php
+@@ -71,7 +71,7 @@ class Attribute implements LayerBuilderInterface
+      */
+     public function build(AggregationInterface $aggregation, ?int $storeId): array
+     {
+-        $attributeOptions = $this->getAttributeOptions($aggregation);
++        $attributeOptions = $this->getAttributeOptions($aggregation, $storeId);
+ 
+         // build layer per attribute
+         $result = [];
+@@ -136,7 +136,7 @@ class Attribute implements LayerBuilderInterface
+      * @return array
+      * @throws \Zend_Db_Statement_Exception
+      */
+-    private function getAttributeOptions(AggregationInterface $aggregation): array
++    private function getAttributeOptions(AggregationInterface $aggregation, $storeId): array
+     {
+         $attributeOptionIds = [];
+         $attributes = [];
+@@ -154,6 +154,6 @@ class Attribute implements LayerBuilderInterface
+             return [];
+         }
+ 
+-        return $this->attributeOptionProvider->getOptions(\array_merge(...$attributeOptionIds), $attributes);
++        return $this->attributeOptionProvider->getOptions(\array_merge(...$attributeOptionIds), $attributes,$storeId);
+     }
+ }

--- a/patches/os/MDVA-30164__fixes_customer_export_when_custom_customer_attribute_exists__2.3.2.patch
+++ b/patches/os/MDVA-30164__fixes_customer_export_when_custom_customer_attribute_exists__2.3.2.patch
@@ -1,0 +1,65 @@
+diff --git a/vendor/magento/module-customer/Ui/Component/DataProvider/Document.php b/vendor/magento/module-customer/Ui/Component/DataProvider/Document.php
+index 468a9e7946f..e802505caf9 100644
+--- a/vendor/magento/module-customer/Ui/Component/DataProvider/Document.php
++++ b/vendor/magento/module-customer/Ui/Component/DataProvider/Document.php
+@@ -5,18 +5,23 @@
+  */
+ namespace Magento\Customer\Ui\Component\DataProvider;
+ 
++use Exception;
+ use Magento\Customer\Api\CustomerMetadataInterface;
++use Magento\Customer\Api\Data\OptionInterface;
++use Magento\Customer\Api\GroupRepositoryInterface;
+ use Magento\Customer\Model\AccountManagement;
+ use Magento\Framework\Api\AttributeValueFactory;
+ use Magento\Framework\App\Config\ScopeConfigInterface;
+-use Magento\Framework\Exception\NoSuchEntityException;
+-use Magento\Customer\Api\GroupRepositoryInterface;
+ use Magento\Framework\App\ObjectManager;
++use Magento\Framework\Exception\NoSuchEntityException;
+ use Magento\Store\Model\ScopeInterface;
+ use Magento\Store\Model\StoreManagerInterface;
+ 
+ /**
+  * Class Document
++ *
++ * Set the attribute label and value for UI Component
++ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+  */
+ class Document extends \Magento\Framework\View\Element\UiComponent\DataProvider\Document
+ {
+@@ -127,7 +132,7 @@ class Document extends \Magento\Framework\View\Element\UiComponent\DataProvider\
+     private function setGenderValue()
+     {
+         $value = $this->getData(self::$genderAttributeCode);
+-        
++
+         if (!$value) {
+             $this->setCustomAttribute(self::$genderAttributeCode, 'N/A');
+             return;
+@@ -135,8 +140,15 @@ class Document extends \Magento\Framework\View\Element\UiComponent\DataProvider\
+ 
+         try {
+             $attributeMetadata = $this->customerMetadata->getAttributeMetadata(self::$genderAttributeCode);
+-            $option = $attributeMetadata->getOptions()[$value];
+-            $this->setCustomAttribute(self::$genderAttributeCode, $option->getLabel());
++            $options = $attributeMetadata->getOptions();
++            array_walk(
++                $options,
++                function (OptionInterface $option) use ($value) {
++                    if ($option->getValue() == $value) {
++                        $this->setCustomAttribute(self::$genderAttributeCode, $option->getLabel());
++                    }
++                }
++            );
+         } catch (NoSuchEntityException $e) {
+             $this->setCustomAttribute(self::$genderAttributeCode, 'N/A');
+         }
+@@ -199,6 +211,7 @@ class Document extends \Magento\Framework\View\Element\UiComponent\DataProvider\
+      * Update lock expires value. Method set account lock text value to match what is shown in grid
+      *
+      * @return void
++     * @throws Exception
+      */
+     private function setAccountLockValue()
+     {

--- a/patches/os/MDVA-30195__fix_to_handle_long_database_names__2.3.4-p2.patch
+++ b/patches/os/MDVA-30195__fix_to_handle_long_database_names__2.3.4-p2.patch
@@ -1,0 +1,56 @@
+diff --git a/vendor/magento/framework/Lock/Backend/Database.php b/vendor/magento/framework/Lock/Backend/Database.php
+index a5a76ba60f4..aa872f9166b 100644
+--- a/vendor/magento/framework/Lock/Backend/Database.php
++++ b/vendor/magento/framework/Lock/Backend/Database.php
+@@ -11,8 +11,8 @@ use Magento\Framework\App\DeploymentConfig;
+ use Magento\Framework\App\ResourceConnection;
+ use Magento\Framework\Config\ConfigOptionsListConstants;
+ use Magento\Framework\Exception\AlreadyExistsException;
+-use Magento\Framework\Exception\InputException;
+ use Magento\Framework\Phrase;
++use Magento\Framework\DB\ExpressionConverter;
+ 
+ /**
+  * Implementation of the lock manager on the basis of MySQL.
+@@ -68,7 +68,6 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+      * @param string $name lock name
+      * @param int $timeout How long to wait lock acquisition in seconds, negative value means infinite timeout
+      * @return bool
+-     * @throws InputException
+      * @throws AlreadyExistsException
+      * @throws \Zend_Db_Statement_Exception
+      */
+@@ -110,7 +109,6 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+      *
+      * @param string $name lock name
+      * @return bool
+-     * @throws InputException
+      * @throws \Zend_Db_Statement_Exception
+      */
+     public function unlock(string $name): bool
+@@ -138,7 +136,6 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+      *
+      * @param string $name lock name
+      * @return bool
+-     * @throws InputException
+      * @throws \Zend_Db_Statement_Exception
+      */
+     public function isLocked(string $name): bool
+@@ -162,15 +159,11 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
+      *
+      * @param string $name
+      * @return string
+-     * @throws InputException
+      */
+     private function addPrefix(string $name): string
+     {
+-        $name = $this->getPrefix() . '|' . $name;
+-
+-        if (strlen($name) > 64) {
+-            throw new InputException(new Phrase('Lock name too long: %1...', [substr($name, 0, 64)]));
+-        }
++        $prefix = $this->getPrefix() ? $this->getPrefix() . '|' : '';
++        $name = ExpressionConverter::shortenEntityName($prefix . $name, $prefix);
+ 
+         return $name;
+     }

--- a/patches/os/MDVA-30209__fixes_customer_group_id_during_account_update__2.3.0.patch
+++ b/patches/os/MDVA-30209__fixes_customer_group_id_during_account_update__2.3.0.patch
@@ -1,0 +1,27 @@
+diff --git a/vendor/magento/module-customer/Model/CustomerExtractor.php b/vendor/magento/module-customer/Model/CustomerExtractor.php
+index be30b979947..6bcc3b8b83c 100644
+--- a/vendor/magento/module-customer/Model/CustomerExtractor.php
++++ b/vendor/magento/module-customer/Model/CustomerExtractor.php
+@@ -88,15 +88,20 @@ class CustomerExtractor
+             $customerData,
+             \Magento\Customer\Api\Data\CustomerInterface::class
+         );
++
+         $store = $this->storeManager->getStore();
++        $storeId = $store->getId();
++
+         if ($isGroupIdEmpty) {
++            $groupId = isset($customerData['group_id']) ? $customerData['group_id']
++                : $this->customerGroupManagement->getDefaultGroup($storeId)->getId();
+             $customerDataObject->setGroupId(
+-                $this->customerGroupManagement->getDefaultGroup($store->getId())->getId()
++                $groupId
+             );
+         }
+ 
+         $customerDataObject->setWebsiteId($store->getWebsiteId());
+-        $customerDataObject->setStoreId($store->getId());
++        $customerDataObject->setStoreId($storeId);
+ 
+         return $customerDataObject;
+     }

--- a/patches/os/MDVA-30232__fixes_issue_with_re-order_when_order_contains_giftcard__2.3.5-p1.patch
+++ b/patches/os/MDVA-30232__fixes_issue_with_re-order_when_order_contains_giftcard__2.3.5-p1.patch
@@ -1,0 +1,40 @@
+diff --git a/vendor/magento/module-sales/Model/Order/ItemRepository.php b/vendor/magento/module-sales/Model/Order/ItemRepository.php
+index 6e029ac4683..345fffc414f 100644
+--- a/vendor/magento/module-sales/Model/Order/ItemRepository.php
++++ b/vendor/magento/module-sales/Model/Order/ItemRepository.php
+@@ -167,10 +167,7 @@ class ItemRepository implements OrderItemRepositoryInterface
+     public function save(OrderItemInterface $entity)
+     {
+         if ($entity->getProductOption()) {
+-            $request = $this->getBuyRequest($entity);
+-            $productOptions = $entity->getProductOptions();
+-            $productOptions['info_buyRequest'] = $request->toArray();
+-            $entity->setProductOptions($productOptions);
++            $entity->setProductOptions($this->getItemProductOptions($entity));
+         }
+ 
+         $this->metadata->getMapper()->save($entity);
+@@ -178,6 +175,23 @@ class ItemRepository implements OrderItemRepositoryInterface
+         return $this->registry[$entity->getEntityId()];
+     }
+ 
++    /**
++     * Return product options
++     *
++     * @param OrderItemInterface $entity
++     * @return array
++     */
++    private function getItemProductOptions(OrderItemInterface $entity): array
++    {
++        $request = $this->getBuyRequest($entity);
++        $productOptions = $entity->getProductOptions();
++        $productOptions['info_buyRequest'] = $productOptions && !empty($productOptions['info_buyRequest'])
++            ? array_merge($productOptions['info_buyRequest'], $request->toArray())
++            : $request->toArray();
++
++        return $productOptions;
++    }
++
+     /**
+      * Set parent item.
+      *

--- a/patches/os/MDVA-30444__fixes_confirmation_email_not_sent_with_orders_placed_using_graphql__2.3.5-p1.patch
+++ b/patches/os/MDVA-30444__fixes_confirmation_email_not_sent_with_orders_placed_using_graphql__2.3.5-p1.patch
@@ -1,0 +1,18 @@
+diff --git a/vendor/magento/module-quote-graph-ql/etc/graphql/events.xml b/vendor/magento/module-quote-graph-ql/etc/graphql/events.xml
+new file mode 100644
+index 00000000000..1e9822bbf3e
+--- /dev/null
++++ b/vendor/magento/module-quote-graph-ql/etc/graphql/events.xml
+@@ -0,0 +1,12 @@
++<?xml version="1.0"?>
++<!--
++/**
++ * Copyright © Magento, Inc. All rights reserved.
++ * See COPYING.txt for license details.
++ */
++-->
++<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
++    <event name="sales_model_service_quote_submit_success">
++        <observer name="sendEmail" instance="Magento\Quote\Observer\SubmitObserver" />
++    </event>
++</config>

--- a/patches/os/MDVA-30490__fixes_500_error_on_product_comparison_when_having_empty_short_product_description__2.3.5-p2.patch
+++ b/patches/os/MDVA-30490__fixes_500_error_on_product_comparison_when_having_empty_short_product_description__2.3.5-p2.patch
@@ -1,0 +1,38 @@
+diff --git a/vendor/magento/module-catalog/Helper/Output.php b/vendor/magento/module-catalog/Helper/Output.php
+index 93b67965e72..bcc409a26c0 100644
+--- a/vendor/magento/module-catalog/Helper/Output.php
++++ b/vendor/magento/module-catalog/Helper/Output.php
+@@ -15,6 +15,7 @@ use Magento\Framework\App\Helper\Context;
+ use Magento\Framework\Escaper;
+ use Magento\Framework\Exception\LocalizedException;
+ use Magento\Framework\Filter\Template;
++use Magento\Framework\Phrase;
+ use function is_object;
+ use function method_exists;
+ use function preg_match;
+@@ -157,7 +158,7 @@ class Output extends AbstractHelper
+      * Prepare product attribute html output
+      *
+      * @param ModelProduct $product
+-     * @param string $attributeHtml
++     * @param string|Phrase $attributeHtml
+      * @param string $attributeName
+      * @return string
+      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+@@ -235,14 +236,14 @@ class Output extends AbstractHelper
+     /**
+      * Check if string has directives
+      *
+-     * @param string $attributeHtml
++     * @param string|Phrase $attributeHtml
+      * @return bool
+      */
+     public function isDirectivesExists($attributeHtml)
+     {
+         $matches = false;
+         foreach ($this->directivePatterns as $pattern) {
+-            if (preg_match($pattern, $attributeHtml)) {
++            if (preg_match($pattern, (string)$attributeHtml)) {
+                 $matches = true;
+                 break;
+             }


### PR DESCRIPTION
### Release Note

| Patch location  | Description |
| ------------- | ------------- |
|os/MDVA-30195__fix_to_handle_long_database_names__2.3.4-p2.patch|Fixes the issue where cron jobs fail if database name is too long, resulting in categories not being updated on the frontend.|
|os/MDVA-30106__fix_validation_for_possible_null_objects_on_validation_rules__2.3.4.patch|Fixes an issue where during checkout payments are not loaded with “Cannot read property ‘length’ of null ” error in JS console.|
|os/MDVA-28656__fixes_order_status_issue_when_invoicing_zero_payment_orders__2.3.5-p1.patch|Fixes the issue where if an order was placed with no payment information required (for example, with 100% discount) and an invoice was created for the order, the order status changes to Closed instead of Complete.|
|os/MDVA-30209__fixes_customer_group_id_during_account_update__2.3.0.patch|Fixes the issue where the customer group was changed to default if customer updated their account information.|
|os/MDVA-30123__fixes_attribute_option_labels_translation_for_graphql_queries__2.3.4.patch|Fixes the issue where attribute option labels are not translated correctly for GraphQL queries.|
|commerce/MDVA-29996__fixes_page_cache_identifier_with_enabled_category_permissions_and_fpc__2.3.3.patch|Fixes the issue where after  enabling category permission, the category page is not getting cached by Full Page Cache.|
|os/MDVA-30164__fixes_customer_export_when_custom_customer_attribute_exists__2.3.2.patch|Fixes the issue where customers records cannot be exported from the Customers grid, if custom customer attributes exist.|
|os/MDVA-30444__fixes_confirmation_email_not_sent_with_orders_placed_using_graphql__2.3.5-p1.patch|Fixes the issue where no confirmation email is sent for orders placed using GraphQL.|
|os/MDVA-30490__fixes_500_error_on_product_comparison_when_having_empty_short_product_description__2.3.5-p2.patch|Fixes the issue where products comparison throws the 500 error page, if one of the products has an empty short description.|
|os/MDVA-30232__fixes_issue_with_re-order_when_order_contains_giftcard__2.3.5-p1.patch|Fixes the issue where it is not possible to re-order if the original order contains a gift card.|
|os/MDVA-29965_fixes_invalid_form_key_error_when_adding_to_cart_before_page_fully_refreshes_2.3.5-p1.patch|Fixes the issue where customers get Invalid Form Key error when adding a product to the cart.|
|commerce/MDVA-30008_fixes_order_placement_via_admin_api_for_public_catalog_products_2.3.3.patch|Fixes the B2B issue where it is not possible to place orders through Admin API for a product which is in a public catalog.|
|os/MDVA-22469_fixes_page_builder_css_and_js_not_loading_2.3.3.patch, commerce/MDVA-22469_fixes_page_builder_css_and_js_not_loading_2.3.3.patch |Fixes the issue where after upgrading to Magento 2.3.3, Page Builder is not working in the Admin panel and some JS and CSS files are not loading. |



### Fixed Issues
1. https://jira.corp.magento.com/browse/MDVA-30195
2. https://jira.corp.magento.com/browse/MDVA-30106
3. https://jira.corp.magento.com/browse/MDVA-28656
4. https://jira.corp.magento.com/browse/MDVA-30209
5. https://jira.corp.magento.com/browse/MDVA-30123
6. https://jira.corp.magento.com/browse/MDVA-29996
7. https://jira.corp.magento.com/browse/MDVA-30164
8. https://jira.corp.magento.com/browse/MDVA-30444
9. https://jira.corp.magento.com/browse/MDVA-30490
10. https://jira.corp.magento.com/browse/MDVA-30232
11. https://jira.corp.magento.com/browse/MDVA-29965
12. https://jira.corp.magento.com/browse/MDVA-30008
13. https://jira.corp.magento.com/browse/MDVA-22469