### PR TITLE
Updated patch constraints configuration according to 2.3.6, 2.4.0-p1, 2.4.1 Magento releases

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -356,7 +356,7 @@
   "MDVA-30102": {
     "magento/magento2-base": {
       "Fixes the issue where Redis cache grows up quickly since layout caches don't have TTL.": {
-        ">=2.3.2 <=2.4.0": {
+        ">=2.3.2 <2.4.2": {
           "file": "os/MDVA-30102__fixes_issue_when_redis_cache_grows_up_quickly__2.3.5.patch"
         }
       }
@@ -365,7 +365,7 @@
   "MDVA-30599": {
     "magento/magento2-base": {
       "Fixes the issue where guest quotes created using API are incorrectly marked as quotes for logged in customers.": {
-        ">=2.3.4 <=2.4.0": {
+        ">=2.3.4 <2.4.2": {
           "file": "os/MDVA-30599__fixes_issue_with_API_created_guest_quotes_marked_as_logged_in_customers_quotes__2.3.5-p2.patch"
         }
       }
@@ -374,7 +374,7 @@
   "MDVA-29446": {
     "magento/magento2-base": {
       "Fixes the issue where the price of not applicable shipping method is shown as zero during checkout.": {
-        ">=2.3.3 <=2.4.0": {
+        ">=2.3.3 <2.4.2": {
           "file": "os/MDVA-29446__fixes_issue_with_non_applicable_shipping_method_price_shown_as_zero_in_checkout__2.3.4.patch"
         }
       }
@@ -405,7 +405,7 @@
   "MDVA-29787": {
     "magento/magento2-ee-base": {
       "Fixes the issue where target rule for related products does not work when 'is one of' condition is used to define products to be displayed.": {
-        ">=2.3.0 <=2.4.0": {
+        ">=2.3.0 <2.4.2": {
           "file": "commerce/MDVA-29787__fixes_condition_is_one_of_not_working_on_target_rules_for_related_products_2.3.3.patch"
         }
       }
@@ -414,14 +414,14 @@
   "MDVA-30977": {
     "magento/magento2-base": {
       "Fixes the issue with random products missing from categories after reindex.": {
-        ">=2.3.4 <=2.3.5-p2": {
+        ">=2.3.4 <2.4.2": {
           "file": "os/MDVA-30977__fixes_issue_with_missing_random_products_from_categories_after_reindex__2.3.5-p1.patch"
         }
       }
     },
     "magento/inventory-metapackage": {
       "Fixes the issue with random products missing from categories after reindex.": {
-        ">=1.1.4 <=1.1.5-p1": {
+        ">=1.1.4 <1.2.2": {
           "file": "os/MDVA-30977__fixes_issue_with_missing_random_products_from_categories_after_reindex__1.1.5-p1.patch"
         }
       }
@@ -430,14 +430,14 @@
   "MDVA-28202": {
     "magento/magento2-base": {
       "Fixes the issue where Layered Navigation doesn't filter configurable products correctly when MSI is used.": {
-        ">=2.3.4 <=2.4.2": {
+        ">=2.3.4 <2.4.2": {
           "file": "os/MDVA-28202__fixes_issue_with_layered_navigation_not_filtering_configurable_products_correctly_with_msi__2.3.5-p1.patch"
         }
       }
     },
     "magento/inventory-metapackage": {
       "Fixes the issue where Layered Navigation doesn't filter configurable products correctly when MSI is used.": {
-        ">=1.1.4 <=1.2.2": {
+        ">=1.1.4 <1.2.2": {
           "file": "os/MDVA-28202__fixes_issue_with_layered_navigation_not_filtering_configurable_products_correctly_with_msi__1.1.5-p1.patch"
         }
       }
@@ -458,7 +458,7 @@
         ">=2.3.2 <2.3.3": {
           "file": "os/MDVA-30730__fixes_issue_with_duplicated_orders_when_using_paypal_express_payment__2.3.2-p2.patch"
         },
-        ">=2.3.3 <=2.4.2": {
+        ">=2.3.3 <2.4.2": {
           "file": "os/MDVA-31006__fixes_issue_with_duplicated_orders_when_using_paypal_express_payment__2.3.5-p2.patch"
         }
       }

--- a/patches.json
+++ b/patches.json
@@ -126,7 +126,7 @@
   "MDVA-28656": {
     "magento/magento2-base": {
       "Fixes the issue where if an order was placed with no payment information required (for example, with 100% discount) and an invoice was created for the order, the order status changes to Closed instead of Complete.": {
-        ">=2.3.1 <2.3.6 || >=2.4.0 <2.4.2": {
+        ">=2.3.1 <2.3.6 || >=2.4.0 <2.4.1": {
           "file": "os/MDVA-28656__fixes_order_status_issue_when_invoicing_zero_payment_orders__2.3.5-p1.patch"
         }
       }
@@ -144,7 +144,7 @@
   "MDVA-30123": {
     "magento/magento2-base": {
       "Fixes the issue where attribute option labels are not translated correctly for GraphQL queries.": {
-        ">=2.3.4 <2.4.2": {
+        ">=2.3.4 <2.3.6 || >=2.4.0 <2.4.1": {
           "file": "os/MDVA-30123__fixes_attribute_option_labels_translation_for_graphql_queries__2.3.4.patch"
         }
       }
@@ -316,7 +316,7 @@
   "MDVA-30428": {
     "magento/magento2-base": {
       "Fixes the issue where customers cannot add a product to wishlist if this product is assigned to a custom inventory source.": {
-        ">=2.3.5 <2.4.2": {
+        ">=2.3.5 <2.3.6 || >=2.4.0 <2.4.1": {
           "file": "os/MDVA-30428__fixes_add_a_product_with_custom_inventory_to_wishlist__2.3.5-p1.patch"
         },
         ">=2.3.3 <2.3.4": {
@@ -326,7 +326,7 @@
     },
     "magento/inventory-metapackage": {
       "Fixes the issue where customers cannot add a product to wishlist if this product is assigned to a custom inventory source.": {
-        ">=1.1.5 <1.2.2": {
+        ">=1.1.5 <1.1.6 || >=1.2.0 <1.2.1": {
           "file": "os/MDVA-30428__fixes_add_a_product_with_custom_inventory_to_wishlist__1.1.5.patch"
         },
         ">=1.1.3 <1.1.4": {
@@ -347,7 +347,7 @@
   "MDVA-28993": {
     "magento/magento2-base": {
       "Implements the \"Minimum should match\" functionality and partial search for Elasticsearch engine. Solves issues with hyphens in search queries.": {
-        ">=2.3.4 <2.4.0": {
+        ">=2.3.4 <2.3.6": {
           "file": "os/MDVA-28993__implements_minimum_should_match_functionality_and_partial_search_for_elasticsearch__2.3.4.patch"
         }
       }
@@ -414,14 +414,14 @@
   "MDVA-30977": {
     "magento/magento2-base": {
       "Fixes the issue with random products missing from categories after reindex.": {
-        ">=2.3.4 <2.4.2": {
+        ">=2.3.4 <2.4.0": {
           "file": "os/MDVA-30977__fixes_issue_with_missing_random_products_from_categories_after_reindex__2.3.5-p1.patch"
         }
       }
     },
     "magento/inventory-metapackage": {
       "Fixes the issue with random products missing from categories after reindex.": {
-        ">=1.1.4 <1.2.2": {
+        ">=1.1.4 <1.2.0": {
           "file": "os/MDVA-30977__fixes_issue_with_missing_random_products_from_categories_after_reindex__1.1.5-p1.patch"
         }
       }

--- a/src/Test/Functional/Acceptance/Acceptance73Cest.php
+++ b/src/Test/Functional/Acceptance/Acceptance73Cest.php
@@ -33,7 +33,10 @@ class Acceptance73Cest extends AcceptanceCest
             ['templateVersion' => '2.3.5', 'magentoVersion' => '2.3.5'],
             ['templateVersion' => '2.3.5', 'magentoVersion' => '2.3.5-p1'],
             ['templateVersion' => '2.3.5', 'magentoVersion' => '2.3.5-p2'],
+            ['templateVersion' => '2.3.5', 'magentoVersion' => '2.3.6'],
             ['templateVersion' => '2.4.0', 'magentoVersion' => '2.4.0'],
+            ['templateVersion' => '2.4.0', 'magentoVersion' => '2.4.0-p1'],
+            ['templateVersion' => '2.4.0', 'magentoVersion' => '2.4.1'],
         ];
     }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->
https://jira.corp.magento.com/browse/MC-38153

### Description
- Magento 2.3.6, 2.4.0-p1, 2.4.1 included into build.
- Incompatible Magento versions were excluded from patch configuration
- For some patches version constraints were extended to include <2.4.2
- Need to update  MQP release notes and related KB articles


**Incompatible patches: Magento 2.3.6**
Patch Id | Description
-- | --
MDVA-30428 | Fixes the issue where customers cannot add a product to wishlist if this product is assigned to a custom inventory source.
MDVA-28993 | Implements the \"Minimum should match\" functionality and partial search for Elasticsearch engine. Solves issues with hyphens in search queries.
MDVA-30123 | Fixes the issue where attribute option labels are not translated correctly for GraphQL queries.

 **Incompatible patches: Magento 2.4.0-p1**

 ** All compatible

 **Incompatible patches: Magento 2.4.1**
Patch Id | Description
-- | --
MDVA-30428 | Fixes the issue where customers cannot add a product to wishlist if this product is assigned to a custom inventory source.
MDVA-28656 | Fixes the issue where if an order was placed with no payment information required (for example, with 100% discount) and an invoice was created for the order, the order status changes to Closed instead of Complete.
MDVA-30123 | Fixes the issue where attribute option labels are not translated correctly for GraphQL queries.


