### PR TITLE
MC-38509: Submitting invalid create account form leaves the submit button disabled

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -643,5 +643,14 @@
         }
       }
     }
+  },
+  "MC-38509": {
+    "magento/magento2-base": {
+      "Fixes the issue where the \"Create an Account\" button left disabled even after correcting invalid create account form.": {
+        ">=2.3.0 <2.3.6-p1 || >=2.4.0 <2.4.2": {
+          "file": "os/MC-38509__fixes_create_account_submit_button_state_after_form_validation__2.4.1.patch"
+        }
+      }
+    }
   }
 }

--- a/patches.json
+++ b/patches.json
@@ -646,8 +646,8 @@
   },
   "MC-38509": {
     "magento/magento2-base": {
-      "Fixes the issue where the \"Create an Account\" button left disabled even after correcting invalid create account form.": {
-        ">=2.3.0 <2.3.6-p1 || >=2.4.0 <2.4.2": {
+      "Fixes the issue where the \"Create an Account\" button stays disabled after correcting invalid data in the \"Create New Customer Account\" form.": {
+        ">=2.3.0 <2.3.6-p1 || >=2.4.0 <2.4.1-p1": {
           "file": "os/MC-38509__fixes_create_account_submit_button_state_after_form_validation__2.4.1.patch"
         }
       }

--- a/patches/os/MC-38509__fixes_create_account_submit_button_state_after_form_validation__2.4.1.patch
+++ b/patches/os/MC-38509__fixes_create_account_submit_button_state_after_form_validation__2.4.1.patch
@@ -1,0 +1,19 @@
+diff -Nuar a/vendor/magento/module-customer/view/frontend/web/js/block-submit-on-send.js b/vendor/magento/module-customer/view/frontend/web/js/block-submit-on-send.js
+--- a/vendor/magento/module-customer/view/frontend/web/js/block-submit-on-send.js
++++ b/vendor/magento/module-customer/view/frontend/web/js/block-submit-on-send.js
+@@ -14,9 +14,15 @@ define([
+ 
+         dataForm.submit(function () {
+             $(this).find(':submit').attr('disabled', 'disabled');
++
++            if (this.isValid === false) {
++                $(this).find(':submit').prop('disabled', false);
++            }
++            this.isValid = true;
+         });
+         dataForm.bind('invalid-form.validate', function () {
+             $(this).find(':submit').prop('disabled', false);
++            this.isValid = false;
+         });
+     };
+ });


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Please provide a description of the patches in the pull request. -->
Fixes the issue where the "Create an Account" button left disabled even after correcting invalid create account form.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format: <jira_issue_link> <jira_issue_title>.
-->
1. https://jira.corp.magento.com/browse/MC-38509
