### PR TITLE
BUNDLE-2833 (Vertex & Free Shipping calculated based on subtotal + tax)

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -1,4 +1,13 @@
 {
+  "BUNDLE-2833": {
+    "vertex/module-tax": {
+      "Allows Vertex-calculated tax to be included when determining free shipping": {
+        ">=3.4.0 <3.5.0 || >=4.0.0 <4.2.0": {
+          "file": "os/BUNDLE-2833__Allows_Vertex_calculated_tax_to_be_included_in_free_shipping.patch"
+        }
+      }
+    }
+  },
   "MDVA-25602": {
     "magento/magento2-base": {
       "Fixes issue with PayPal Payflow Pro payment method and treating cookies as SameSite=Lax by default in the Chrome 80 browser and API response redirect to customer login page": {

--- a/patches/os/BUNDLE-2833__Allows_Vertex_calculated_tax_to_be_included_in_free_shipping.patch
+++ b/patches/os/BUNDLE-2833__Allows_Vertex_calculated_tax_to_be_included_in_free_shipping.patch
@@ -1,0 +1,26 @@
+From cf7ae73421bc8d5d0193a00f129f7a1a66deeb81 Mon Sep 17 00:00:00 2001
+From: Navarr Barnier <navarr.barnier@blueacornici.com>
+Date: Wed, 11 Nov 2020 14:14:32 -0500
+Subject: [PATCH] VRTX-843: Allow processing of Vertex taxes during subtotal
+
+Issues: VRTX-843, BUNDLE-2833
+---
+ Model/Plugin/SubtotalPlugin.php               | 65 -------------------
+ etc/di.xml                                    | 11 ++--
+ 3 files changed, 48 insertions(+), 71 deletions(-)
+ delete mode 100644 Model/Plugin/SubtotalPlugin.php
+
+
+diff --git a/vendor/vertex/module-tax/etc/di.xml b/vendor/vertex/module-tax/etc/di.xml
+--- a/vendor/vertex/module-tax/etc/di.xml
++++ b/vendor/vertex/module-tax/etc/di.xml
+@@ -118,9 +120,6 @@
+     <type name="Magento\Tax\Model\Sales\Total\Quote\CommonTaxCollector">
+         <plugin name="vertexItemLevelMap" type="Vertex\Tax\Model\Plugin\CommonTaxCollectorPlugin" sortOrder="1"/>
+     </type>
+-    <type name="Magento\Tax\Model\Sales\Total\Quote\Subtotal">
+-        <plugin name="vertexDoesNotCalculateSubtotal" type="Vertex\Tax\Model\Plugin\SubtotalPlugin" sortOrder="10"/>
+-    </type>
+     <type name="Magento\Tax\Model\Sales\Total\Quote\Tax">
+         <plugin name="vertexOrderLevelMap" type="Vertex\Tax\Model\Plugin\TaxPlugin" sortOrder="1"/>
+     </type>


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
This patch resolves an issue where Free Shipping does not consider the tax on the order when determining whether or not it can apply (when configured to consider tax)

### Fixed Issues (if relevant)
1. [BUNDLE-2833](https://jira.corp.magento.com/browse/BUNDLE-2833)
