### PR TITLE
added patch and config

### DIFF
--- a/patches/os/MAGE-3381_2.4.3.patch
+++ b/patches/os/MAGE-3381_2.4.3.patch
@@ -1,0 +1,23 @@
+diff -Naur a/vendor/klarna/module-core/Cron/CleanLogs.php b/vendor/klarna/module-core/Cron/CleanLogs.php
+--- a/vendor/klarna/module-core/Cron/CleanLogs.php
++++ b/vendor/klarna/module-core/Cron/CleanLogs.php
+@@ -138,7 +138,6 @@ class CleanLogs
+         $lifetime *= self::SECONDSINDAY;
+
+         $logs = $this->logCollectionFactory->create();
+-        $logs->addFieldToFilter('store_id', $store->getId());
+         $logs->addFieldToFilter('created_at', ['to' => date("Y-m-d", time() - $lifetime)]);
+
+         return $logs;
+diff -Naur a/vendor/klarna/module-core/etc/db_schema.xml b/vendor/klarna/module-core/etc/db_schema.xml
+--- a/vendor/klarna/module-core/etc/db_schema.xml
++++ b/vendor/klarna/module-core/etc/db_schema.xml
+@@ -36,7 +36,7 @@
+     </table>
+
+     <table name="klarna_logs" resource="default" engine="innodb" comment="Klarna Logs">
+-        <column xsi:type="smallint" name="log_id" unsigned="false" nullable="false" identity="true" comment="Log Id"/>
++        <column xsi:type="int" name="log_id" unsigned="true" nullable="false" identity="true" comment="Log Id"/>
+         <column xsi:type="varchar" name="status" nullable="false" length="255" comment="Status"/>
+         <column xsi:type="varchar" name="action" length="255" comment="Action"/>
+         <column xsi:type="varchar" name="klarna_id" length="255" comment="Klarna Id"/>

--- a/support-patches.json
+++ b/support-patches.json
@@ -3633,5 +3633,18 @@
                 }
             }
         }
+    },
+    "MAGE-3381": {
+        "categories": [
+            "Checkout", "Cron"
+        ],
+        "title": "Fixes the issue where the customers see a blank page on checkout step because of  `Out of range value for column` DB error.",
+        "packages": {
+            "klarna/m2-payments": {
+                ">=8.3.0 <=8.3.6": {
+                    "file": "os/MAGE-3381_2.4.3.patch"
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
The Klarna module introduced changes to the logging of API requests. In db_schema.xml the primary key was set to smallint (signed), which means the table can only handle 32767 records. When the table becomes full, the checkout fails to load due to a unique contraint violation error (which can be traced back to not being able to add any more records to the log table), resulting in a blank page.

This fix will increase the number of possible entries for the Klarna requests logging table. Hence, the checkout won't fail to load anymore. The amount of possible entries is going from 32767 to 4294967295 rows.

It also fixes a malformed select query, that is triggered via a cron job, which is supposed to clean up this table from entries older than **x** days. The query contained a where condition on a column store_id, but that column does not exist on the table.

Fixed Issues
https://jira.int.klarna.net/jira/browse/MAGE-3381
