### PR TITLE
Automatically generated patch for magento/magento2#34228

### DIFF
--- a/community-patches.json
+++ b/community-patches.json
@@ -12,5 +12,18 @@
                 }
             }
         }
+    },
+    "magento/magento2/34228": {
+        "categories": [
+            "Payments"
+        ],
+        "title": "Author: @konarshankar07. Added patch for the upgrade issue from 2.4.2 to 2.4.3",
+        "packages": {
+            "magento2-base": {
+                "2.4.3": {
+                    "file": "community/magento_magento2_34228.patch"
+                }
+            }
+        }
     }
 }

--- a/community-release-notes.json
+++ b/community-release-notes.json
@@ -10,6 +10,16 @@
                     "description": "\"Optimize QuoteIdToMaskedQuoteId model\": Improve performance by using direct SQL queries"
                 }
             ]
+        },
+        {
+            "version": "1.1.4",
+            "patches": [
+                {
+                    "code": "magento2-base",
+                    "magento-version": "2.4.3",
+                    "description": "\"Added patch for the upgrade issue from 2.4.2 to 2.4.3\": Fixes Upgrade Issue, While upgrade from Magento 2.4.2-p1 to Magento 2.4.3 for PayPal data patch"
+                }
+            ]
         }
     ]
 }

--- a/community-release-notes.md
+++ b/community-release-notes.md
@@ -1,4 +1,9 @@
 
+## v1.1.4
+
+-  **magento2-base** _(for Magento `2.4.3`)_-"Added patch for the upgrade issue from 2.4.2 to 2.4.3": Fixes Upgrade Issue, While upgrade from Magento 2.4.2-p1 to Magento 2.4.3 for PayPal data patch
+
 ## v1.1.2
 
 -  **magento2-base** _(for Magento `2.3.7`)_-"Optimize QuoteIdToMaskedQuoteId model": Improve performance by using direct SQL queries
+

--- a/patches/community/magento_magento2_34228.patch
+++ b/patches/community/magento_magento2_34228.patch
@@ -1,0 +1,23 @@
+From 70a652f56e4739651badbeca05b0d463a850f0b7 Mon Sep 17 00:00:00 2001
+From: shankar <konar.shankar2013@gmail.com>
+Date: Sun, 3 Oct 2021 16:42:17 +0530
+Subject: [PATCH] Added patch for the upgrade issue from 2.4.2 to 2.4.3
+
+---
+ .../Magento/Paypal/Setup/Patch/Data/UpdateBmltoPayLater.php    | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/vendor/magento/module-paypal/Setup/Patch/Data/UpdateBmltoPayLater.php b/vendor/magento/module-paypal/Setup/Patch/Data/UpdateBmltoPayLater.php
+index 449b130fa992..9684c60cbdd6 100644
+--- a/vendor/magento/module-paypal/Setup/Patch/Data/UpdateBmltoPayLater.php
++++ b/vendor/magento/module-paypal/Setup/Patch/Data/UpdateBmltoPayLater.php
+@@ -134,6 +134,9 @@ public function apply()
+         foreach ($bmlSettings as $bmlPath => $bmlValue) {
+             $setting = str_replace(self::BMLPATH, '', $bmlPath);
+             $settingParts = explode('_', $setting);
++            if (count($settingParts) !== 2) {
++                continue;
++            }
+             $page = $settingParts[0];
+             $setting = $settingParts[1];
+             $payLaterPage = $page === 'checkout' ? 'cartpage' : $page;


### PR DESCRIPTION
### Title
Added patch for the upgrade issue from 2.4.2 to 2.4.3

### Patch Description
Pull request is automatically generated and contains Magento composer based installation patch based on magento/magento2#34228 pull request provided by @konarshankar07

### Release Notes
Fixes Upgrade Issue, While upgrade from Magento 2.4.2-p1 to Magento 2.4.3 for PayPal data patch

### Patch Category
Payments

### Supported version(s)
2.4.3

### Affected Files
[app/code/Magento/Paypal/Setup/Patch/Data/UpdateBmltoPayLater.php](https://github.com/magento/magento2/raw/70a652f56e4739651badbeca05b0d463a850f0b7/app/code/Magento/Paypal/Setup/Patch/Data/UpdateBmltoPayLater.php)
