### PR TITLE
Automatically generated patch for magento/magento2#34170

### DIFF
--- a/community-patches.json
+++ b/community-patches.json
@@ -25,5 +25,18 @@
                 }
             }
         }
+    },
+    "magento/magento2/34170": {
+        "categories": [
+            "Payments"
+        ],
+        "title": "backport  #28137  to 2.3. Author: @jonashrem",
+        "packages": {
+            "magento2-base": {
+                "2.3.7": {
+                    "file": "community/magento_magento2_34170.patch"
+                }
+            }
+        }
     }
 }

--- a/community-release-notes.json
+++ b/community-release-notes.json
@@ -18,6 +18,11 @@
                     "code": "magento2-base",
                     "magento-version": "2.4.3",
                     "description": "\"Added patch for the upgrade issue from 2.4.2 to 2.4.3\": Fixes Upgrade Issue, While upgrade from Magento 2.4.2-p1 to Magento 2.4.3 for PayPal data patch"
+                },
+                {
+                    "code": "magento2-base",
+                    "magento-version": "2.3.7",
+                    "description": "\"backport  #28137  to 2.3\": Fixes issue with Varnish 6 when 503 error was returned and VCL error Too many restarts in logs"
                 }
             ]
         }

--- a/community-release-notes.md
+++ b/community-release-notes.md
@@ -2,6 +2,7 @@
 ## v1.1.4
 
 -  **magento2-base** _(for Magento `2.4.3`)_-"Added patch for the upgrade issue from 2.4.2 to 2.4.3": Fixes Upgrade Issue, While upgrade from Magento 2.4.2-p1 to Magento 2.4.3 for PayPal data patch
+-  **magento2-base** _(for Magento `2.3.7`)_-"backport  #28137  to 2.3": Fixes issue with Varnish 6 when 503 error was returned and VCL error Too many restarts in logs
 
 ## v1.1.2
 

--- a/patches/community/magento_magento2_34170.patch
+++ b/patches/community/magento_magento2_34170.patch
@@ -1,0 +1,24 @@
+From 0d6154dd43b535db4cf7365e28c1bbc78a541e9f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jonas=20H=C3=BCnig?= <jonas@huenig.name>
+Date: Mon, 27 Sep 2021 14:26:56 +0200
+Subject: [PATCH] backport  #24353  to 2.3
+
+backports #24353  to Magento 2.3
+---
+ vendor/magento/module-page-cache/etc/varnish6.vcl | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/vendor/magento/module-page-cache/etc/varnish6.vcl b/vendor/magento/module-page-cache/etc/varnish6.vcl
+index b43c8a77bca7..14f82dbed3ca 100644
+--- a/vendor/magento/module-page-cache/etc/varnish6.vcl
++++ b/vendor/magento/module-page-cache/etc/varnish6.vcl
+@@ -23,6 +23,9 @@ acl purge {
+ }
+ 
+ sub vcl_recv {
++    if (req.restarts > 0) {
++        set req.hash_always_miss = true;
++    }
+     if (req.method == "PURGE") {
+         if (client.ip !~ purge) {
+             return (synth(405, "Method not allowed"));


### PR DESCRIPTION
### Title
backport  #28137  to 2.3

### Patch Description
Pull request is automatically generated and contains Magento composer based installation patch based on magento/magento2#34170 pull request provided by @jonashrem

### Release Notes
Fixes issue with Varnish 6 when 503 error was returned and VCL error Too many restarts in logs

### Patch Category
Payments

### Supported version(s)
2.3.7

### Affected Files
[app/code/Magento/PageCache/etc/varnish6.vcl](https://github.com/magento/magento2/raw/220ce5240cbe5028836c6ac0f4b3910f766793be/app/code/Magento/PageCache/etc/varnish6.vcl)
