### PR TITLE
Automatically generated patch for magento/magento2#34529

### DIFF
--- a/community-patches.json
+++ b/community-patches.json
@@ -38,5 +38,18 @@
                 }
             }
         }
+    },
+    "magento/magento2/34529": {
+        "categories": [
+            "N/A"
+        ],
+        "title": "MC-41887: Validation Messages - CustomerData messages not showing up. Author: @Den4ik",
+        "packages": {
+            "magento/magento2-base": {
+                "2.3.7": {
+                    "file": "community/magento_magento2_34529.patch"
+                }
+            }
+        }
     }
 }

--- a/community-release-notes.json
+++ b/community-release-notes.json
@@ -25,6 +25,16 @@
                     "description": "\"backport  #28137  to 2.3\": Fixes issue with Varnish 6 when 503 error was returned and VCL error Too many restarts in logs"
                 }
             ]
+        },
+        {
+            "version": "1.1.6",
+            "patches": [
+                {
+                    "code": "magento/magento2-base",
+                    "magento-version": "2.3.7",
+                    "description": "\"MC-41887: Validation Messages - CustomerData messages not showing up\": N/A"
+                }
+            ]
         }
     ]
 }

--- a/community-release-notes.md
+++ b/community-release-notes.md
@@ -1,4 +1,8 @@
 
+## v1.1.6
+
+-  **magento/magento2-base** _(for Magento `2.3.7`)_-"MC-41887: Validation Messages - CustomerData messages not showing up": N/A
+
 ## v1.1.4
 
 -  **magento2-base** _(for Magento `2.4.3`)_-"Added patch for the upgrade issue from 2.4.2 to 2.4.3": Fixes Upgrade Issue, While upgrade from Magento 2.4.2-p1 to Magento 2.4.3 for PayPal data patch

--- a/patches/community/magento_magento2_34529.patch
+++ b/patches/community/magento_magento2_34529.patch
@@ -1,0 +1,399 @@
+From 05a3d9a857fa05f3dd560741ee529c0b1f8e5064 Mon Sep 17 00:00:00 2001
+From: Denis Kopylov <dkopylov@magenius.team>
+Date: Thu, 4 Nov 2021 13:23:26 +0300
+Subject: [PATCH] MC-41887: Validation Messages - CustomerData messages not
+ showing up
+
+Signed-off-by: Denis Kopylov <dkopylov@magenius.team>
+---
+ .../Theme/Controller/Result/MessagePlugin.php |  14 ++-
+ .../Controller/Result/MessagePluginTest.php   | 118 +++++++++++++-----
+ 2 files changed, 99 insertions(+), 33 deletions(-)
+
+diff --git a/vendor/magento/module-theme/Controller/Result/MessagePlugin.php b/vendor/magento/module-theme/Controller/Result/MessagePlugin.php
+index e8b50d9cfc5d..7635c4a9cd46 100644
+--- a/vendor/magento/module-theme/Controller/Result/MessagePlugin.php
++++ b/vendor/magento/module-theme/Controller/Result/MessagePlugin.php
+@@ -3,6 +3,7 @@
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
++
+ namespace Magento\Theme\Controller\Result;
+ 
+ use Magento\Framework\App\ObjectManager;
+@@ -11,6 +12,7 @@
+ use Magento\Framework\Message\MessageInterface;
+ use Magento\Framework\Translate\Inline\ParserInterface;
+ use Magento\Framework\Translate\InlineInterface;
++use Magento\Framework\Session\Config\ConfigInterface;
+ 
+ /**
+  * Plugin for putting messages to cookies
+@@ -54,6 +56,11 @@ class MessagePlugin
+      */
+     private $inlineTranslate;
+ 
++    /**
++     * @var ConfigInterface
++     */
++    protected $sessionConfig;
++
+     /**
+      * @param \Magento\Framework\Stdlib\CookieManagerInterface $cookieManager
+      * @param \Magento\Framework\Stdlib\Cookie\CookieMetadataFactory $cookieMetadataFactory
+@@ -61,6 +68,7 @@ class MessagePlugin
+      * @param \Magento\Framework\View\Element\Message\InterpretationStrategyInterface $interpretationStrategy
+      * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+      * @param InlineInterface|null $inlineTranslate
++     * @param ConfigInterface|null $sessionConfig
+      */
+     public function __construct(
+         \Magento\Framework\Stdlib\CookieManagerInterface $cookieManager,
+@@ -68,7 +76,8 @@ public function __construct(
+         \Magento\Framework\Message\ManagerInterface $messageManager,
+         \Magento\Framework\View\Element\Message\InterpretationStrategyInterface $interpretationStrategy,
+         \Magento\Framework\Serialize\Serializer\Json $serializer = null,
+-        InlineInterface $inlineTranslate = null
++        InlineInterface $inlineTranslate = null,
++        ConfigInterface $sessionConfig = null
+     ) {
+         $this->cookieManager = $cookieManager;
+         $this->cookieMetadataFactory = $cookieMetadataFactory;
+@@ -77,6 +86,7 @@ public function __construct(
+             ->get(\Magento\Framework\Serialize\Serializer\Json::class);
+         $this->interpretationStrategy = $interpretationStrategy;
+         $this->inlineTranslate = $inlineTranslate ?: ObjectManager::getInstance()->get(InlineInterface::class);
++        $this->sessionConfig = $sessionConfig ?: ObjectManager::getInstance()->get(ConfigInterface::class);
+     }
+ 
+     /**
+@@ -132,7 +142,7 @@ private function setCookie(array $messages)
+ 
+             $publicCookieMetadata = $this->cookieMetadataFactory->createPublicCookieMetadata();
+             $publicCookieMetadata->setDurationOneYear();
+-            $publicCookieMetadata->setPath('/');
++            $publicCookieMetadata->setPath($this->sessionConfig->getCookiePath());
+             $publicCookieMetadata->setHttpOnly(false);
+             $publicCookieMetadata->setSameSite('Strict');
+ 
+diff --git a/vendor/magento/module-theme/Test/Unit/Controller/Result/MessagePluginTest.php b/vendor/magento/module-theme/Test/Unit/Controller/Result/MessagePluginTest.php
+index 8dc4c659745b..8ea3bff4a828 100644
+--- a/vendor/magento/module-theme/Test/Unit/Controller/Result/MessagePluginTest.php
++++ b/vendor/magento/module-theme/Test/Unit/Controller/Result/MessagePluginTest.php
+@@ -3,6 +3,7 @@
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
++
+ namespace Magento\Theme\Test\Unit\Controller\Result;
+ 
+ use Magento\Framework\Controller\Result\Json;
+@@ -15,8 +16,10 @@
+ use Magento\Framework\Stdlib\Cookie\PublicCookieMetadata;
+ use Magento\Framework\Stdlib\CookieManagerInterface;
+ use Magento\Framework\Translate\InlineInterface;
++use Magento\Framework\Session\Config\ConfigInterface;
+ use Magento\Framework\View\Element\Message\InterpretationStrategyInterface;
+ use Magento\Theme\Controller\Result\MessagePlugin;
++use PHPUnit\Framework\MockObject\MockObject;
+ 
+ /**
+  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+@@ -26,24 +29,29 @@ class MessagePluginTest extends \PHPUnit\Framework\TestCase
+     /** @var MessagePlugin */
+     protected $model;
+ 
+-    /** @var CookieManagerInterface|\PHPUnit\Framework\MockObject\MockObject */
++    /** @var CookieManagerInterface|MockObject */
+     protected $cookieManagerMock;
+ 
+-    /** @var CookieMetadataFactory|\PHPUnit\Framework\MockObject\MockObject */
++    /** @var CookieMetadataFactory|MockObject */
+     protected $cookieMetadataFactoryMock;
+ 
+-    /** @var ManagerInterface|\PHPUnit\Framework\MockObject\MockObject */
++    /** @var ManagerInterface|MockObject */
+     protected $managerMock;
+ 
+-    /** @var InterpretationStrategyInterface|\PHPUnit\Framework\MockObject\MockObject */
++    /** @var InterpretationStrategyInterface|MockObject */
+     protected $interpretationStrategyMock;
+ 
+-    /** @var \Magento\Framework\Serialize\Serializer\Json|\PHPUnit\Framework\MockObject\MockObject */
++    /** @var \Magento\Framework\Serialize\Serializer\Json|MockObject */
+     private $serializerMock;
+ 
+-    /** @var InlineInterface|\PHPUnit\Framework\MockObject\MockObject */
++    /** @var InlineInterface|MockObject */
+     private $inlineTranslateMock;
+ 
++    /**
++     * @var ConfigInterface|MockObject
++     */
++    protected $sessionConfigMock;
++
+     protected function setUp(): void
+     {
+         $this->cookieManagerMock = $this->getMockBuilder(CookieManagerInterface::class)
+@@ -58,6 +66,8 @@ protected function setUp(): void
+         $this->serializerMock = $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)
+             ->getMock();
+         $this->inlineTranslateMock = $this->getMockBuilder(InlineInterface::class)->getMockForAbstractClass();
++        $this->sessionConfigMock = $this->getMockBuilder(ConfigInterface::class)
++            ->getMockForAbstractClass();
+ 
+         $this->model = new MessagePlugin(
+             $this->cookieManagerMock,
+@@ -65,13 +75,14 @@ protected function setUp(): void
+             $this->managerMock,
+             $this->interpretationStrategyMock,
+             $this->serializerMock,
+-            $this->inlineTranslateMock
++            $this->inlineTranslateMock,
++            $this->sessionConfigMock
+         );
+     }
+ 
+     public function testAfterRenderResultJson()
+     {
+-        /** @var Json|\PHPUnit\Framework\MockObject\MockObject $resultMock */
++        /** @var Json|MockObject $resultMock */
+         $resultMock = $this->getMockBuilder(Json::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+@@ -99,13 +110,13 @@ public function testAfterRenderResult()
+             ],
+         ];
+         $messages = array_merge($existingMessages, $messages);
+-        
+-        /** @var Redirect|\PHPUnit\Framework\MockObject\MockObject $resultMock */
++
++        /** @var Redirect|MockObject $resultMock */
+         $resultMock = $this->getMockBuilder(Redirect::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+ 
+-        /** @var PublicCookieMetadata|\PHPUnit\Framework\MockObject\MockObject $cookieMetadataMock */
++        /** @var PublicCookieMetadata|MockObject $cookieMetadataMock */
+         $cookieMetadataMock = $this->getMockBuilder(PublicCookieMetadata::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+@@ -143,7 +154,7 @@ function ($data) {
+                 }
+             );
+ 
+-        /** @var MessageInterface|\PHPUnit\Framework\MockObject\MockObject $messageMock */
++        /** @var MessageInterface|MockObject $messageMock */
+         $messageMock = $this->getMockBuilder(MessageInterface::class)
+             ->getMock();
+         $messageMock->expects($this->once())
+@@ -155,7 +166,7 @@ function ($data) {
+             ->with($messageMock)
+             ->willReturn($messageText);
+ 
+-        /** @var Collection|\PHPUnit\Framework\MockObject\MockObject $collectionMock */
++        /** @var Collection|MockObject $collectionMock */
+         $collectionMock = $this->getMockBuilder(Collection::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+@@ -173,7 +184,7 @@ function ($data) {
+ 
+     public function testAfterRenderResultWithNoMessages()
+     {
+-        /** @var Redirect|\PHPUnit\Framework\MockObject\MockObject $resultMock */
++        /** @var Redirect|MockObject $resultMock */
+         $resultMock = $this->getMockBuilder(Redirect::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+@@ -195,7 +206,7 @@ function ($data) {
+         $this->serializerMock->expects($this->never())
+             ->method('serialize');
+ 
+-        /** @var Collection|\PHPUnit\Framework\MockObject\MockObject $collectionMock */
++        /** @var Collection|MockObject $collectionMock */
+         $collectionMock = $this->getMockBuilder(Collection::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+@@ -226,12 +237,12 @@ public function testAfterRenderResultWithoutExisting()
+             ],
+         ];
+ 
+-        /** @var Redirect|\PHPUnit\Framework\MockObject\MockObject $resultMock */
++        /** @var Redirect|MockObject $resultMock */
+         $resultMock = $this->getMockBuilder(Redirect::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+ 
+-        /** @var PublicCookieMetadata|\PHPUnit\Framework\MockObject\MockObject $cookieMetadataMock */
++        /** @var PublicCookieMetadata|MockObject $cookieMetadataMock */
+         $cookieMetadataMock = $this->getMockBuilder(PublicCookieMetadata::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+@@ -269,7 +280,7 @@ function ($data) {
+                 }
+             );
+ 
+-        /** @var MessageInterface|\PHPUnit\Framework\MockObject\MockObject $messageMock */
++        /** @var MessageInterface|MockObject $messageMock */
+         $messageMock = $this->getMockBuilder(MessageInterface::class)
+             ->getMock();
+         $messageMock->expects($this->once())
+@@ -281,7 +292,7 @@ function ($data) {
+             ->with($messageMock)
+             ->willReturn($messageText);
+ 
+-        /** @var Collection|\PHPUnit\Framework\MockObject\MockObject $collectionMock */
++        /** @var Collection|MockObject $collectionMock */
+         $collectionMock = $this->getMockBuilder(Collection::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+@@ -308,12 +319,12 @@ public function testAfterRenderResultWithWrongJson()
+             ],
+         ];
+ 
+-        /** @var Redirect|\PHPUnit\Framework\MockObject\MockObject $resultMock */
++        /** @var Redirect|MockObject $resultMock */
+         $resultMock = $this->getMockBuilder(Redirect::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+ 
+-        /** @var PublicCookieMetadata|\PHPUnit\Framework\MockObject\MockObject $cookieMetadataMock */
++        /** @var PublicCookieMetadata|MockObject $cookieMetadataMock */
+         $cookieMetadataMock = $this->getMockBuilder(PublicCookieMetadata::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+@@ -347,7 +358,7 @@ function ($data) {
+                 }
+             );
+ 
+-        /** @var MessageInterface|\PHPUnit\Framework\MockObject\MockObject $messageMock */
++        /** @var MessageInterface|MockObject $messageMock */
+         $messageMock = $this->getMockBuilder(MessageInterface::class)
+             ->getMock();
+         $messageMock->expects($this->once())
+@@ -359,7 +370,7 @@ function ($data) {
+             ->with($messageMock)
+             ->willReturn($messageText);
+ 
+-        /** @var Collection|\PHPUnit\Framework\MockObject\MockObject $collectionMock */
++        /** @var Collection|MockObject $collectionMock */
+         $collectionMock = $this->getMockBuilder(Collection::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+@@ -386,12 +397,12 @@ public function testAfterRenderResultWithWrongArray()
+             ],
+         ];
+ 
+-        /** @var Redirect|\PHPUnit\Framework\MockObject\MockObject $resultMock */
++        /** @var Redirect|MockObject $resultMock */
+         $resultMock = $this->getMockBuilder(Redirect::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+ 
+-        /** @var PublicCookieMetadata|\PHPUnit\Framework\MockObject\MockObject $cookieMetadataMock */
++        /** @var PublicCookieMetadata|MockObject $cookieMetadataMock */
+         $cookieMetadataMock = $this->getMockBuilder(PublicCookieMetadata::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+@@ -429,7 +440,7 @@ function ($data) {
+                 }
+             );
+ 
+-        /** @var MessageInterface|\PHPUnit\Framework\MockObject\MockObject $messageMock */
++        /** @var MessageInterface|MockObject $messageMock */
+         $messageMock = $this->getMockBuilder(MessageInterface::class)
+             ->getMock();
+         $messageMock->expects($this->once())
+@@ -441,7 +452,7 @@ function ($data) {
+             ->with($messageMock)
+             ->willReturn($messageText);
+ 
+-        /** @var Collection|\PHPUnit\Framework\MockObject\MockObject $collectionMock */
++        /** @var Collection|MockObject $collectionMock */
+         $collectionMock = $this->getMockBuilder(Collection::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+@@ -471,12 +482,12 @@ public function testAfterRenderResultWithAllowedInlineTranslate(): void
+             ],
+         ];
+ 
+-        /** @var Redirect|\PHPUnit\Framework\MockObject\MockObject $resultMock */
++        /** @var Redirect|MockObject $resultMock */
+         $resultMock = $this->getMockBuilder(Redirect::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+ 
+-        /** @var PublicCookieMetadata|\PHPUnit\Framework\MockObject\MockObject $cookieMetadataMock */
++        /** @var PublicCookieMetadata|MockObject $cookieMetadataMock */
+         $cookieMetadataMock = $this->getMockBuilder(PublicCookieMetadata::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+@@ -514,7 +525,7 @@ function ($data) {
+                 }
+             );
+ 
+-        /** @var MessageInterface|\PHPUnit\Framework\MockObject\MockObject $messageMock */
++        /** @var MessageInterface|MockObject $messageMock */
+         $messageMock = $this->getMockBuilder(MessageInterface::class)
+             ->getMock();
+         $messageMock->expects($this->once())
+@@ -530,7 +541,7 @@ function ($data) {
+             ->method('isAllowed')
+             ->willReturn(true);
+ 
+-        /** @var Collection|\PHPUnit\Framework\MockObject\MockObject $collectionMock */
++        /** @var Collection|MockObject $collectionMock */
+         $collectionMock = $this->getMockBuilder(Collection::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+@@ -545,4 +556,49 @@ function ($data) {
+ 
+         $this->assertEquals($resultMock, $this->model->afterRenderResult($resultMock, $resultMock));
+     }
++
++    public function testSetCookieWithCookiePath()
++    {
++        /** @var Redirect|MockObject $resultMock */
++        $resultMock = $this->getMockBuilder(Redirect::class)
++            ->disableOriginalConstructor()
++            ->getMock();
++
++        /** @var PublicCookieMetadata|MockObject $cookieMetadataMock */
++        $cookieMetadataMock = $this->getMockBuilder(PublicCookieMetadata::class)
++            ->disableOriginalConstructor()
++            ->getMock();
++
++        $this->cookieMetadataFactoryMock->expects($this->once())
++            ->method('createPublicCookieMetadata')
++            ->willReturn($cookieMetadataMock);
++
++        /** @var MessageInterface|MockObject $messageMock */
++        $messageMock = $this->getMockBuilder(MessageInterface::class)
++            ->getMock();
++
++        /** @var Collection|MockObject $collectionMock */
++        $collectionMock = $this->getMockBuilder(Collection::class)
++            ->disableOriginalConstructor()
++            ->getMock();
++        $collectionMock->expects($this->once())
++            ->method('getItems')
++            ->willReturn([$messageMock]);
++
++        $this->managerMock->expects($this->once())
++            ->method('getMessages')
++            ->with(true, null)
++            ->willReturn($collectionMock);
++
++        /* Test that getCookiePath is called during cookie setup */
++        $this->sessionConfigMock->expects($this->once())
++            ->method('getCookiePath')
++            ->willReturn('/pub');
++        $cookieMetadataMock->expects($this->once())
++            ->method('setPath')
++            ->with('/pub')
++            ->willReturn($cookieMetadataMock);
++
++        $this->model->afterRenderResult($resultMock, $resultMock);
++    }
+ }


### PR DESCRIPTION
### Title
MC-41887: Validation Messages - CustomerData messages not showing up

### Patch Description
Pull request is automatically generated and contains Magento composer based installation patch based on magento/magento2#34529 pull request provided by @Den4ik

### Release Notes
N/A

### Patch Category
N/A

### Supported version(s)
2.3.7

### Affected Files
[app/code/Magento/Theme/Controller/Result/MessagePlugin.php](https://github.com/magento/magento2/raw/05a3d9a857fa05f3dd560741ee529c0b1f8e5064/app/code/Magento/Theme/Controller/Result/MessagePlugin.php)
[app/code/Magento/Theme/Test/Unit/Controller/Result/MessagePluginTest.php](https://github.com/magento/magento2/raw/05a3d9a857fa05f3dd560741ee529c0b1f8e5064/app/code/Magento/Theme/Test/Unit/Controller/Result/MessagePluginTest.php)
