### PR TITLE
MDVA-41061 update compatibility version

### DIFF
--- a/support-patches.json
+++ b/support-patches.json
@@ -3936,7 +3936,7 @@
         "title": "Fixes the issue where stock status resets to salable when a product is saved from Admin.",
         "packages": {
             "magento/magento2-base": {
-                ">=2.4.2 <2.4.3": {
+                ">=2.4.2 <= 2.4.3-p1": {
                     "file": "os/MDVA-41061_2.4.2-p1_v2.patch"
                 }
             },


### PR DESCRIPTION
MDVA-41061 compatibility version need update

### Description
In the documentation it mentioned for the MDVA-41061 patch : https://support.magento.com/hc/en-us/articles/4413139771149-MDVA-41061-Stock-status-resets-to-saleable-when-product-saved-from-Admin
`... Please note that the issue is scheduled to be fixed in Adobe Commerce 2.4.4.`
And :
`Compatible with Adobe Commerce versions: Adobe Commerce (all deployment methods) 2.3.5 - 2.4.3-p1`

But in support-patches.json there is a limitation on the version : ">=2.4.2 <2.4.3"

`"MDVA-41061": { "categories": [ "Inventory" ], "title": "Fixes the issue where stock status resets to salable when a product is saved from Admin.", "packages": { "magento/magento2-base": { ">=2.4.2 <2.4.3": { "file": "os/MDVA-41061_2.4.2-p1_v2.patch" } }, "magento/inventory-metapackage": { "1.2.2": { "file": "os/MDVA-41061_1.2.2_v2.patch" } } } },`
