### PR TITLE
Community patch: Braintree PayPal cart button — guard missing clientToken (magento/magento2#40622)

### DIFF
--- a/community-patches.json
+++ b/community-patches.json
@@ -65,5 +65,18 @@
                 }
             }
         }
+    },
+    "magento/magento2/40622": {
+        "categories": [
+            "Payments"
+        ],
+        "title": "PayPal Braintree: avoid INSTANTIATION_OPTION_REQUIRED when clientToken is missing (cart PayPal button JS). Author: @Genaker. See magento/magento2#40622.",
+        "packages": {
+            "magento/magento2-base": {
+                "2.4.8": {
+                    "file": "community/magento_magento2_40622_braintree_paypal_button.patch"
+                }
+            }
+        }
     }
 }

--- a/patches/community/magento_magento2_40622_braintree_paypal_button.patch
+++ b/patches/community/magento_magento2_40622_braintree_paypal_button.patch
@@ -1,0 +1,12 @@
+--- a/vendor/paypal/module-braintree-core/view/frontend/web/js/paypal/button.js	2026-03-24 00:04:41.716453736 -0700
++++ b/vendor/paypal/module-braintree-core/view/frontend/web/js/paypal/button.js	2026-03-24 00:04:41.736453720 -0700
+@@ -180,6 +180,9 @@
+              * @param buttonConfig
+              */
+             loadSDK: function (buttonConfig) {
++                if (!buttonConfig || !buttonConfig.clientToken) {
++                    return;
++                }
+                 // Load SDK
+                 braintree.create({
+                     authorization: buttonConfig.clientToken


### PR DESCRIPTION
## Summary
Adds a **community quality patch** for `paypal/module-braintree-core` (`PayPal_Braintree`): `loadSDK` in `view/frontend/web/js/paypal/button.js` now returns early when `clientToken` is missing, consistent with `express-paypal.js`, so the Braintree SDK is not called with an empty `authorization` (fixes `INSTANTIATION_OPTION_REQUIRED` / `options.authorization is required when instantiating a client`).

## Magento issue
- https://github.com/magento/magento2/issues/40622

## Patch file
- `patches/community/magento_magento2_40622_braintree_paypal_button.patch`
- Targets `vendor/paypal/module-braintree-core/view/frontend/web/js/paypal/button.js` (project root).

## Package version
Registered for `magento/magento2-base` **2.4.8** (adjust or extend versions as needed for other lines).

## Testing
- `patch -p1 --dry-run` applied cleanly against a 2.4.8 install with `paypal/module-braintree-core` 4.7.x.